### PR TITLE
Reply styling bringup

### DIFF
--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -36,12 +36,12 @@ ThemeData _buildReplyLightTheme(BuildContext context) {
       backgroundColor: ReplyColors.blue700,
       selectedIconTheme: const IconThemeData(color: ReplyColors.orange500),
       selectedLabelTextStyle:
-          GoogleFonts.workSansTextTheme().copyWith().headline5.copyWith(
+          GoogleFonts.workSansTextTheme().headline5.copyWith(
                 color: ReplyColors.orange500,
               ),
       unselectedIconTheme: const IconThemeData(color: ReplyColors.blue200),
       unselectedLabelTextStyle:
-          GoogleFonts.workSansTextTheme().copyWith().headline5.copyWith(
+          GoogleFonts.workSansTextTheme().headline5.copyWith(
                 color: ReplyColors.blue200,
               ),
     ),

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:gallery/data/gallery_options.dart';
 import 'package:gallery/l10n/gallery_localizations.dart';
 import 'package:gallery/studies/reply/inbox.dart';
+import 'package:gallery/studies/reply/colors.dart';
+import 'package:gallery/layout/letter_spacing.dart';
 
 class ReplyApp extends StatelessWidget {
   const ReplyApp();
@@ -13,6 +16,7 @@ class ReplyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Reply',
       debugShowCheckedModeBanner: false,
+      theme: _buildReplyLightTheme(context),
       localizationsDelegates: GalleryLocalizations.localizationsDelegates,
       supportedLocales: GalleryLocalizations.supportedLocales,
       locale: GalleryOptions.of(context).locale,
@@ -22,4 +26,91 @@ class ReplyApp extends StatelessWidget {
       },
     );
   }
+}
+
+ThemeData _buildReplyLightTheme(BuildContext context) {
+  final base = ThemeData.light();
+  return base.copyWith(
+    scaffoldBackgroundColor: ReplyColors.blue50,
+    navigationRailTheme: NavigationRailThemeData(
+      backgroundColor: ReplyColors.blue700,
+      selectedIconTheme: const IconThemeData(color: ReplyColors.orange500),
+      selectedLabelTextStyle:
+          GoogleFonts.workSansTextTheme().copyWith().headline5.copyWith(
+                color: ReplyColors.orange500,
+              ),
+      unselectedIconTheme: const IconThemeData(color: ReplyColors.blue200),
+      unselectedLabelTextStyle:
+          GoogleFonts.workSansTextTheme().copyWith().headline5.copyWith(
+                color: ReplyColors.blue200,
+              ),
+    ),
+    colorScheme: const ColorScheme.light(
+      primary: ReplyColors.blue700,
+      primaryVariant: ReplyColors.blue800,
+      secondary: ReplyColors.orange500,
+      secondaryVariant: ReplyColors.orange400,
+      surface: ReplyColors.white50,
+      error: ReplyColors.red400,
+      onPrimary: ReplyColors.white50,
+      onSecondary: ReplyColors.black900,
+      onBackground: ReplyColors.black900,
+      onSurface: ReplyColors.black900,
+      onError: ReplyColors.black900,
+      background: ReplyColors.blue50,
+    ),
+    canvasColor: ReplyColors.white50,
+    accentColor: ReplyColors.orange500,
+    textTheme: _buildReplyTextTheme(
+      GoogleFonts.workSansTextTheme(Theme.of(context).textTheme),
+    ),
+  );
+}
+
+TextTheme _buildReplyTextTheme(TextTheme base) {
+  return base.copyWith(
+    headline4: base.headline4.copyWith(
+      fontWeight: FontWeight.w600,
+      fontSize: 34,
+      letterSpacing: letterSpacingOrNone(0.4),
+      height: 0.9,
+      color: ReplyColors.black900,
+    ),
+    headline5: base.headline5.copyWith(
+      fontWeight: FontWeight.bold,
+      fontSize: 24,
+      letterSpacing: letterSpacingOrNone(0.27),
+      color: ReplyColors.black900,
+    ),
+    headline6: base.headline6.copyWith(
+      fontWeight: FontWeight.w600,
+      fontSize: 20,
+      letterSpacing: letterSpacingOrNone(0.18),
+      color: ReplyColors.black900,
+    ),
+    subtitle2: base.subtitle2.copyWith(
+      fontWeight: FontWeight.w600,
+      fontSize: 14,
+      letterSpacing: letterSpacingOrNone(-0.04),
+      color: ReplyColors.black900,
+    ),
+    bodyText1: base.bodyText1.copyWith(
+      fontWeight: FontWeight.normal,
+      fontSize: 18,
+      letterSpacing: letterSpacingOrNone(0.2),
+      color: ReplyColors.black900,
+    ),
+    bodyText2: base.bodyText2.copyWith(
+      fontWeight: FontWeight.normal,
+      fontSize: 14,
+      letterSpacing: letterSpacingOrNone(-0.05),
+      color: ReplyColors.black900,
+    ),
+    caption: base.caption.copyWith(
+      fontWeight: FontWeight.normal,
+      fontSize: 12,
+      letterSpacing: letterSpacingOrNone(0.2),
+      color: ReplyColors.black900,
+    ),
+  );
 }

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -61,52 +61,50 @@ ThemeData _buildReplyLightTheme(BuildContext context) {
     ),
     canvasColor: ReplyColors.white50,
     accentColor: ReplyColors.orange500,
-    textTheme: _buildReplyTextTheme(
-      GoogleFonts.workSansTextTheme(Theme.of(context).textTheme),
-    ),
+    textTheme: _buildReplyTextTheme(base.textTheme),
   );
 }
 
 TextTheme _buildReplyTextTheme(TextTheme base) {
   return base.copyWith(
-    headline4: base.headline4.copyWith(
+    headline4: GoogleFonts.workSans(
       fontWeight: FontWeight.w600,
       fontSize: 34,
       letterSpacing: letterSpacingOrNone(0.4),
       height: 0.9,
       color: ReplyColors.black900,
     ),
-    headline5: base.headline5.copyWith(
+    headline5: GoogleFonts.workSans(
       fontWeight: FontWeight.bold,
       fontSize: 24,
       letterSpacing: letterSpacingOrNone(0.27),
       color: ReplyColors.black900,
     ),
-    headline6: base.headline6.copyWith(
+    headline6: GoogleFonts.workSans(
       fontWeight: FontWeight.w600,
       fontSize: 20,
       letterSpacing: letterSpacingOrNone(0.18),
       color: ReplyColors.black900,
     ),
-    subtitle2: base.subtitle2.copyWith(
+    subtitle2: GoogleFonts.workSans(
       fontWeight: FontWeight.w600,
       fontSize: 14,
       letterSpacing: letterSpacingOrNone(-0.04),
       color: ReplyColors.black900,
     ),
-    bodyText1: base.bodyText1.copyWith(
+    bodyText1: GoogleFonts.workSans(
       fontWeight: FontWeight.normal,
       fontSize: 18,
       letterSpacing: letterSpacingOrNone(0.2),
       color: ReplyColors.black900,
     ),
-    bodyText2: base.bodyText2.copyWith(
+    bodyText2: GoogleFonts.workSans(
       fontWeight: FontWeight.normal,
       fontSize: 14,
       letterSpacing: letterSpacingOrNone(-0.05),
       color: ReplyColors.black900,
     ),
-    caption: base.caption.copyWith(
+    caption: GoogleFonts.workSans(
       fontWeight: FontWeight.normal,
       fontSize: 12,
       letterSpacing: letterSpacingOrNone(0.2),

--- a/lib/studies/reply/colors.dart
+++ b/lib/studies/reply/colors.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class ReplyColors {
+  static const Color white50 = Color(0xFFFFFFFF);
+
+  static const Color black800 = Color(0xFF121212);
+  static const Color black900 = Color(0xFF000000);
+
+  static const Color blue50 = Color(0xFFEEF0F2);
+  static const Color blue100 = Color(0xFFD2DBE0);
+  static const Color blue200 = Color(0xFFADBBC4);
+  static const Color blue300 = Color(0xFF8CA2AE);
+  static const Color blue600 = Color(0xFF4A6572);
+  static const Color blue700 = Color(0xFF344955);
+  static const Color blue800 = Color(0xFF232F34);
+
+  static const Color orange300 = Color(0xFFFBD790);
+  static const Color orange400 = Color(0xFFF9BE64);
+  static const Color orange500 = Color(0xFFF9AA33);
+
+  static const Color red200 = Color(0xFFCF7779);
+  static const Color red400 = Color(0xFFFF4C5D);
+
+  static const Color white50Alpha060 = Color(0x99FFFFFF);
+
+  static const Color blue50Alpha060 = Color(0x99EEF0F2);
+
+  static const Color black900Alpha020 = Color(0x33000000);
+  static const Color black900Alpha087 = Color(0xDE000000);
+  static const Color black900Alpha060 = Color(0x99000000);
+}

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -88,6 +88,7 @@ class _BuildDesktopNav extends StatefulWidget {
 class _BuildDesktopNavState extends State<_BuildDesktopNav>
     with SingleTickerProviderStateMixin {
   bool _isExtended;
+  bool _hasWidgetUpdated = false;
   AnimationController _controller;
 
   @override
@@ -95,12 +96,17 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
     super.initState();
     _isExtended = widget.extended;
     _controller = AnimationController(
-        duration: const Duration(milliseconds: 300), vsync: this)
+        duration: const Duration(milliseconds: 350), vsync: this)
       ..addListener(() {
         if (_controller.isCompleted) {
           _controller.reset();
           setState(() {
-            _isExtended = !_isExtended;
+            if (_hasWidgetUpdated) {
+              _isExtended = widget.extended;
+              _hasWidgetUpdated = false;
+            } else {
+              _isExtended = !_isExtended;
+            }
           });
         }
       });
@@ -111,6 +117,7 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
     super.didUpdateWidget(oldWidget);
     if (oldWidget.extended != widget.extended) {
       onLogoTapped();
+      _hasWidgetUpdated = true;
     }
   }
 
@@ -145,11 +152,11 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                 SizedBox(height: _isExtended ? 8 : 24),
                 Row(
                   children: [
-                    const SizedBox(width: 4),
                     InkWell(
                       borderRadius: const BorderRadius.all(Radius.circular(16)),
                       child: Row(
                         children: [
+                          const SizedBox(width: 4),
                           RotationTransition(
                             turns:
                                 Tween(begin: _isExtended ? 0.0 : 0.5, end: 1.0)
@@ -157,7 +164,7 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                             child: const Icon(
                               Icons.arrow_left,
                               color: Colors.white,
-                              size: 20,
+                              size: 16,
                             ),
                           ),
                           const ImageIcon(
@@ -165,7 +172,7 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                             size: 32,
                             color: Colors.white,
                           ),
-                          const SizedBox(width: 12),
+                          const SizedBox(width: 16),
                           Text(
                             _isExtended ? 'REPLY' : '',
                             style: Theme.of(context)

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -126,8 +126,8 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
 
   @override
   void dispose() {
-    super.dispose();
     _controller.dispose();
+    super.dispose();
   }
 
   @override
@@ -188,11 +188,12 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                                 color: ReplyColors.blue50,
                               ),
                               const SizedBox(width: 10),
-                              Text(
-                                _isExtended ? 'REPLY' : '',
-                                style: textTheme.bodyText1
-                                    .copyWith(color: ReplyColors.blue50),
-                              ),
+                              if (_isExtended)
+                                Text(
+                                  'REPLY',
+                                  style: textTheme.bodyText1
+                                      .copyWith(color: ReplyColors.blue50),
+                                ),
                             ],
                           ),
                           onTap: onLogoTapped,
@@ -237,16 +238,17 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                     heroTag: 'Rail FAB',
                     isExtended: _isExtended,
                     onPressed: () {
-                      /// TODO: Implement onPressed for FAB
+                      // TODO: Implement onPressed for FAB
                     },
                     label: Row(
                       children: [
                         const Icon(Icons.create),
                         SizedBox(width: _isExtended ? 16 : 0),
-                        Text(
-                          _isExtended ? 'COMPOSE' : '',
-                          style: textTheme.headline5.copyWith(fontSize: 16),
-                        ),
+                        if (_isExtended)
+                          Text(
+                            'COMPOSE',
+                            style: textTheme.headline5.copyWith(fontSize: 16),
+                          ),
                       ],
                     ),
                   ),

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -84,21 +84,39 @@ class _BuildDesktopNav extends StatefulWidget {
   _BuildDesktopNavState createState() => _BuildDesktopNavState();
 }
 
-class _BuildDesktopNavState extends State<_BuildDesktopNav> {
+class _BuildDesktopNavState extends State<_BuildDesktopNav>
+    with SingleTickerProviderStateMixin {
   bool _isExtended;
+  AnimationController _controller;
 
   @override
   void initState() {
     super.initState();
     _isExtended = widget.extended;
+    _controller = AnimationController(
+        duration: const Duration(milliseconds: 300), vsync: this)
+      ..addListener(() {
+        if (_controller.isCompleted) {
+          _controller.reset();
+          setState(() {
+            _isExtended = !_isExtended;
+          });
+        }
+      });
   }
 
   @override
   void didUpdateWidget(_BuildDesktopNav oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.extended != widget.extended) {
-      _isExtended = widget.extended;
+      onLogoTapped();
     }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _controller.dispose();
   }
 
   @override
@@ -119,25 +137,50 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav> {
             leading: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                const SizedBox(height: 16),
                 Row(
                   children: [
-                    const SizedBox(width: 25),
+                    const SizedBox(width: 4),
                     InkWell(
-                      child: const Icon(Icons.menu),
-                      onTap: () {
-                        setState(() {
-                          _isExtended = !_isExtended;
-                        });
-                      },
+                      borderRadius: const BorderRadius.all(Radius.circular(16)),
+                      child: Row(
+                        children: [
+                          RotationTransition(
+                            turns:
+                                Tween(begin: _isExtended ? 0.0 : 0.5, end: 1.0)
+                                    .animate(_controller.view),
+                            child: const Icon(
+                              Icons.arrow_left,
+                              color: Colors.white,
+                              size: 20,
+                            ),
+                          ),
+                          const ImageIcon(
+                            AssetImage('assets/reply/reply_logo.png'),
+                            size: 32,
+                            color: Colors.white,
+                          ),
+                          const SizedBox(width: 12),
+                          Text(
+                            _isExtended ? 'REPLY' : '',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyText1
+                                .copyWith(color: Colors.white),
+                          ),
+                        ],
+                      ),
+                      onTap: onLogoTapped,
                     ),
                   ],
                 ),
-                const SizedBox(height: 24),
+                const SizedBox(height: 32),
                 Padding(
                   padding: EdgeInsetsDirectional.only(
                     start: _isExtended ? 12 : 4,
                   ),
                   child: FloatingActionButton.extended(
+                    heroTag: 'Rail FAB',
                     isExtended: _isExtended,
                     onPressed: () {
                       /// TODO: Implement onPressed for FAB
@@ -161,6 +204,7 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav> {
                     ),
                   ),
                 ),
+                const SizedBox(height: 10)
               ],
             ),
             selectedIndex: widget.selectedIndex,
@@ -175,6 +219,14 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav> {
         ],
       ),
     );
+  }
+
+  void onLogoTapped() {
+    if (_isExtended) {
+      _controller.animateTo(0.5);
+    } else {
+      _controller.animateTo(1);
+    }
   }
 }
 

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:gallery/l10n/gallery_localizations.dart';
+import 'package:gallery/studies/reply/colors.dart';
 import 'package:gallery/studies/reply/responsive_widget.dart';
 
 class InboxPage extends StatelessWidget {
@@ -137,7 +138,7 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
             leading: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const SizedBox(height: 16),
+                const SizedBox(height: 32),
                 Row(
                   children: [
                     const SizedBox(width: 4),
@@ -172,6 +173,25 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                       ),
                       onTap: onLogoTapped,
                     ),
+                    _isExtended
+                        ? Row(
+                            children: [
+                              const SizedBox(width: 50),
+                              ClipOval(
+                                child: Image.asset(
+                                  'assets/reply/avatars/avatar_0.jpg',
+                                  width: 32,
+                                  height: 32,
+                                ),
+                              ),
+                              const SizedBox(width: 10),
+                              const Icon(
+                                Icons.settings,
+                                color: ReplyColors.blue200,
+                              ),
+                            ],
+                          )
+                        : const SizedBox(),
                   ],
                 ),
                 const SizedBox(height: 32),

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -241,12 +241,8 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                     },
                     label: Row(
                       children: [
-                        Padding(
-                          padding: EdgeInsetsDirectional.only(
-                            end: _isExtended ? 16 : 0,
-                          ),
-                          child: const Icon(Icons.create),
-                        ),
+                        const Icon(Icons.create),
+                        SizedBox(width: _isExtended? 16 : 0),
                         Text(
                           _isExtended ? 'COMPOSE' : '',
                           style: textTheme.headline5.copyWith(fontSize: 16),

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -150,7 +150,13 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav> {
                           ),
                           child: const Icon(Icons.create),
                         ),
-                        Text(_isExtended ? 'COMPOSE' : ''),
+                        Text(
+                          _isExtended ? 'COMPOSE' : '',
+                          style: Theme.of(context)
+                              .textTheme
+                              .headline5
+                              .copyWith(fontSize: 16),
+                        ),
                       ],
                     ),
                   ),

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:gallery/l10n/gallery_localizations.dart';
 import 'package:gallery/studies/reply/responsive_widget.dart';
@@ -115,16 +116,44 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav> {
             ],
             extended: _isExtended,
             labelType: NavigationRailLabelType.none,
-            leading: Row(
+            leading: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const SizedBox(width: 25),
-                InkWell(
-                  child: const Icon(Icons.menu),
-                  onTap: () {
-                    setState(() {
-                      _isExtended = !_isExtended;
-                    });
-                  },
+                Row(
+                  children: [
+                    const SizedBox(width: 25),
+                    InkWell(
+                      child: const Icon(Icons.menu),
+                      onTap: () {
+                        setState(() {
+                          _isExtended = !_isExtended;
+                        });
+                      },
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                Padding(
+                  padding: EdgeInsetsDirectional.only(
+                    start: _isExtended ? 12 : 4,
+                  ),
+                  child: FloatingActionButton.extended(
+                    isExtended: _isExtended,
+                    onPressed: () {
+                      /// TODO: Implement onPressed for FAB
+                    },
+                    label: Row(
+                      children: [
+                        Padding(
+                          padding: EdgeInsetsDirectional.only(
+                            end: _isExtended ? 16 : 0,
+                          ),
+                          child: const Icon(Icons.create),
+                        ),
+                        Text(_isExtended ? 'COMPOSE' : ''),
+                      ],
+                    ),
+                  ),
                 ),
               ],
             ),

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:gallery/l10n/gallery_localizations.dart';
 import 'package:gallery/studies/reply/colors.dart';

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -242,7 +242,7 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                     label: Row(
                       children: [
                         const Icon(Icons.create),
-                        SizedBox(width: _isExtended? 16 : 0),
+                        SizedBox(width: _isExtended ? 16 : 0),
                         Text(
                           _isExtended ? 'COMPOSE' : '',
                           style: textTheme.headline5.copyWith(fontSize: 16),

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -4,6 +4,9 @@ import 'package:gallery/l10n/gallery_localizations.dart';
 import 'package:gallery/studies/reply/colors.dart';
 import 'package:gallery/studies/reply/responsive_widget.dart';
 
+const _assetsPackage = 'flutter_gallery_assets';
+const _iconAssetLocation = 'reply/icons';
+
 class InboxPage extends StatelessWidget {
   const InboxPage();
 
@@ -28,12 +31,12 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
     final localizations = GalleryLocalizations.of(context);
 
     final _navigationItems = <String, String>{
-      localizations.replyInboxLabel: 'assets/reply/icons/twotone_inbox.png',
-      localizations.replyStarredLabel: 'assets/reply/icons/twotone_star.png',
-      localizations.replySentLabel: 'assets/reply/icons/twotone_send.png',
-      localizations.replyTrashLabel: 'assets/reply/icons/twotone_delete.png',
-      localizations.replySpamLabel: 'assets/reply/icons/twotone_error.png',
-      localizations.replyDraftsLabel: 'assets/reply/icons/twotone_drafts.png',
+      localizations.replyInboxLabel: '$_iconAssetLocation/twotone_inbox.png',
+      localizations.replyStarredLabel: '$_iconAssetLocation/twotone_star.png',
+      localizations.replySentLabel: '$_iconAssetLocation/twotone_send.png',
+      localizations.replyTrashLabel: '$_iconAssetLocation/twotone_delete.png',
+      localizations.replySpamLabel: '$_iconAssetLocation/twotone_error.png',
+      localizations.replyDraftsLabel: '$_iconAssetLocation/twotone_drafts.png',
     };
 
     return ResponsiveWidget(
@@ -129,6 +132,8 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
 
   @override
   Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
     return Scaffold(
       body: Row(
         children: [
@@ -139,6 +144,7 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                   icon: ImageIcon(
                     AssetImage(
                       widget.destinations[destination],
+                      package: _assetsPackage,
                     ),
                   ),
                   label: Text(destination),
@@ -149,71 +155,83 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
             leading: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                SizedBox(height: _isExtended ? 8 : 24),
-                Row(
-                  children: [
-                    InkWell(
-                      borderRadius: const BorderRadius.all(Radius.circular(16)),
-                      child: Row(
-                        children: [
-                          const SizedBox(width: 4),
-                          RotationTransition(
-                            turns:
-                                Tween(begin: _isExtended ? 0.0 : 0.5, end: 1.0)
-                                    .animate(_controller.view),
-                            child: const Icon(
-                              Icons.arrow_left,
-                              color: Colors.white,
-                              size: 16,
-                            ),
+                SizedBox(
+                  height: 56,
+                  child: Row(
+                    children: [
+                      const SizedBox(width: 12),
+                      SizedBox(
+                        width: _isExtended ? 120 : 58,
+                        child: InkWell(
+                          borderRadius: const BorderRadius.all(
+                            Radius.circular(16),
                           ),
-                          const ImageIcon(
-                            AssetImage('assets/reply/reply_logo.png'),
-                            size: 32,
-                            color: Colors.white,
-                          ),
-                          const SizedBox(width: 16),
-                          Text(
-                            _isExtended ? 'REPLY' : '',
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodyText1
-                                .copyWith(color: Colors.white),
-                          ),
-                        ],
-                      ),
-                      onTap: onLogoTapped,
-                    ),
-                    _isExtended
-                        ? Row(
+                          child: Row(
                             children: [
-                              const SizedBox(width: 50),
-                              Column(
-                                children: [
-                                  ClipOval(
-                                    child: Image.asset(
-                                      'assets/reply/avatars/avatar_0.jpg',
-                                      width: 32,
-                                      height: 32,
-                                    ),
-                                  ),
-                                  const SizedBox(height: 32),
-                                ],
+                              RotationTransition(
+                                turns: Tween(
+                                  begin: _isExtended ? 0.0 : 0.5,
+                                  end: 1.0,
+                                ).animate(_controller.view),
+                                child: const Icon(
+                                  Icons.arrow_left,
+                                  color: ReplyColors.blue50,
+                                  size: 16,
+                                ),
+                              ),
+                              const ImageIcon(
+                                AssetImage(
+                                  'reply/reply_logo.png',
+                                  package: _assetsPackage,
+                                ),
+                                size: 32,
+                                color: ReplyColors.blue50,
                               ),
                               const SizedBox(width: 10),
-                              const Icon(
-                                Icons.settings,
-                                color: ReplyColors.blue200,
+                              Text(
+                                _isExtended ? 'REPLY' : '',
+                                style: textTheme.bodyText1
+                                    .copyWith(color: ReplyColors.blue50),
                               ),
                             ],
-                          )
-                        : const SizedBox(),
-                  ],
+                          ),
+                          onTap: onLogoTapped,
+                        ),
+                      ),
+                      _isExtended
+                          ? SizedBox(
+                              width: 128,
+                              child: Row(
+                                children: [
+                                  const SizedBox(width: 36),
+                                  Align(
+                                    alignment: const Alignment(0, -1.5),
+                                    child: ClipOval(
+                                      child: Image.asset(
+                                        'reply/avatars/avatar_2.jpg',
+                                        package: _assetsPackage,
+                                        width: 32,
+                                        height: 32,
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  const Icon(
+                                    Icons.settings,
+                                    color: ReplyColors.blue200,
+                                  ),
+                                ],
+                              ),
+                            )
+                          : const SizedBox(),
+                    ],
+                  ),
                 ),
                 const SizedBox(height: 20),
                 Padding(
-                  padding: EdgeInsetsDirectional.only(
-                    start: _isExtended ? 12 : 4,
+                  padding: const EdgeInsetsDirectional.only(
+                    start: 12,
+                    end: 16,
                   ),
                   child: FloatingActionButton.extended(
                     heroTag: 'Rail FAB',
@@ -231,15 +249,13 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                         ),
                         Text(
                           _isExtended ? 'COMPOSE' : '',
-                          style: Theme.of(context)
-                              .textTheme
-                              .headline5
-                              .copyWith(fontSize: 16),
+                          style: textTheme.headline5.copyWith(fontSize: 16),
                         ),
                       ],
                     ),
                   ),
                 ),
+                const SizedBox(height: 8),
               ],
             ),
             selectedIndex: widget.selectedIndex,

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -27,13 +27,13 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
   Widget build(BuildContext context) {
     final localizations = GalleryLocalizations.of(context);
 
-    final _navigationItems = <String, IconData>{
-      localizations.replyInboxLabel: Icons.inbox,
-      localizations.replyStarredLabel: Icons.star_border,
-      localizations.replySentLabel: Icons.send,
-      localizations.replyTrashLabel: Icons.delete_outline,
-      localizations.replySpamLabel: Icons.error_outline,
-      localizations.replyDraftsLabel: Icons.drafts,
+    final _navigationItems = <String, String>{
+      localizations.replyInboxLabel: 'assets/reply/icons/twotone_inbox.png',
+      localizations.replyStarredLabel: 'assets/reply/icons/twotone_star.png',
+      localizations.replySentLabel: 'assets/reply/icons/twotone_send.png',
+      localizations.replyTrashLabel: 'assets/reply/icons/twotone_delete.png',
+      localizations.replySpamLabel: 'assets/reply/icons/twotone_error.png',
+      localizations.replyDraftsLabel: 'assets/reply/icons/twotone_drafts.png',
     };
 
     return ResponsiveWidget(
@@ -78,7 +78,7 @@ class _BuildDesktopNav extends StatefulWidget {
   /// The dart implementation of a Map defaults to a LinkedHashMap, allowing us
   /// to preserve the order of our elements, so our destinations will always be
   /// in the same order regardless of navigation type.
-  final Map<String, IconData> destinations;
+  final Map<String, String> destinations;
   final void Function(int) onItemTapped;
 
   @override
@@ -129,7 +129,11 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
             destinations: [
               for (var destination in widget.destinations.keys)
                 NavigationRailDestination(
-                  icon: Icon(widget.destinations[destination]),
+                  icon: ImageIcon(
+                    AssetImage(
+                      widget.destinations[destination],
+                    ),
+                  ),
                   label: Text(destination),
                 ),
             ],
@@ -138,7 +142,7 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
             leading: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const SizedBox(height: 32),
+                SizedBox(height: _isExtended ? 8 : 24),
                 Row(
                   children: [
                     const SizedBox(width: 4),
@@ -177,12 +181,17 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                         ? Row(
                             children: [
                               const SizedBox(width: 50),
-                              ClipOval(
-                                child: Image.asset(
-                                  'assets/reply/avatars/avatar_0.jpg',
-                                  width: 32,
-                                  height: 32,
-                                ),
+                              Column(
+                                children: [
+                                  ClipOval(
+                                    child: Image.asset(
+                                      'assets/reply/avatars/avatar_0.jpg',
+                                      width: 32,
+                                      height: 32,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 32),
+                                ],
                               ),
                               const SizedBox(width: 10),
                               const Icon(
@@ -194,7 +203,7 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                         : const SizedBox(),
                   ],
                 ),
-                const SizedBox(height: 32),
+                const SizedBox(height: 20),
                 Padding(
                   padding: EdgeInsetsDirectional.only(
                     start: _isExtended ? 12 : 4,
@@ -224,7 +233,6 @@ class _BuildDesktopNavState extends State<_BuildDesktopNav>
                     ),
                   ),
                 ),
-                const SizedBox(height: 10)
               ],
             ),
             selectedIndex: widget.selectedIndex,
@@ -254,7 +262,7 @@ class _BuildMobileNav extends StatelessWidget {
   const _BuildMobileNav(
       {this.selectedIndex, this.destinations, this.onItemTapped});
   final int selectedIndex;
-  final Map<String, IconData> destinations;
+  final Map<String, String> destinations;
   final void Function(int) onItemTapped;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -142,6 +142,34 @@ flutter:
     - packages/flutter_gallery_assets/fortnightly/fortnightly_stocks.png
     - packages/flutter_gallery_assets/fortnightly/fortnightly_title.png
     - packages/flutter_gallery_assets/fortnightly/fortnightly_war.png
+#    - packages/flutter_gallery_assets/reply/attachments/paris_1.jpg
+#    - packages/flutter_gallery_assets/reply/attachments/paris_2.jpg
+#    - packages/flutter_gallery_assets/reply/attachments/paris_3.jpg
+#    - packages/flutter_gallery_assets/reply/attachments/paris_4.jpg
+#    - packages/flutter_gallery_assets/reply/avatars/avatar_0.jpg
+#    - packages/flutter_gallery_assets/reply/avatars/avatar_1.jpg
+#    - packages/flutter_gallery_assets/reply/avatars/avatar_2.jpg
+#    - packages/flutter_gallery_assets/reply/avatars/avatar_3.jpg
+#    - packages/flutter_gallery_assets/reply/avatars/avatar_4.jpg
+#    - packages/flutter_gallery_assets/reply/avatars/avatar_5.jpg
+#    - packages/flutter_gallery_assets/reply/avatars/avatar_6.jpg
+#    - packages/flutter_gallery_assets/reply/avatars/avatar_7.jpg
+#    - packages/flutter_gallery_assets/reply/avatars/avatar_8.jpg
+#    - packages/flutter_gallery_assets/reply/avatars/avatar_9.jpg
+#    - packages/flutter_gallery_assets/reply/avatars/avatar_10.jpg
+#    - packages/flutter_gallery_assets/reply/avatars/avatar_express.png
+#    - packages/flutter_gallery_assets/reply/icons/twotone_add_circle_outline.png
+#    - packages/flutter_gallery_assets/reply/icons/twotone_delete.png
+#    - packages/flutter_gallery_assets/reply/icons/twotone_drafts.png
+#    - packages/flutter_gallery_assets/reply/icons/twotone_error.png
+#    - packages/flutter_gallery_assets/reply/icons/twotone_folder.png
+#    - packages/flutter_gallery_assets/reply/icons/twotone_forward.png
+#    - packages/flutter_gallery_assets/reply/icons/twotone_inbox.png
+#    - packages/flutter_gallery_assets/reply/icons/twotone_send.png
+#    - packages/flutter_gallery_assets/reply/icons/twotone_star_on_background.png
+#    - packages/flutter_gallery_assets/reply/icons/twotone_star.png
+#    - packages/flutter_gallery_assets/reply/icons/twotone_stars.png
+#    - packages/flutter_gallery_assets/reply/reply_logo.png
     - packages/flutter_gallery_assets/places/india_chennai_flower_market.png
     - packages/flutter_gallery_assets/places/india_thanjavur_market.png
     - packages/flutter_gallery_assets/places/india_tanjore_bronze_works.png

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   vector_math: ^2.0.8
   shared_preferences: ^0.5.4
   collection: ^1.14.0
-  flutter_gallery_assets: ^0.2.2
+  flutter_gallery_assets: ^0.2.4
   package_info: ^0.4.0
   google_fonts: ^1.0.0
   flutter_staggered_grid_view: ^0.3.0
@@ -90,11 +90,11 @@ flutter:
     - packages/flutter_gallery_assets/fonts/google_fonts/Montserrat-Regular.ttf
     - packages/flutter_gallery_assets/fonts/google_fonts/Rubik-Regular.ttf
     - packages/flutter_gallery_assets/fonts/google_fonts/Eczar-SemiBold.ttf
-    #- packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-Regular.ttf
-    #- packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-Medium.ttf
-    #- packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-Bold.ttf
-    #- packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-Thin.ttf
-    #- packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-SemiBold.ttf
+    - packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-Regular.ttf
+    - packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-Medium.ttf
+    - packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-Bold.ttf
+    - packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-Thin.ttf
+    - packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-SemiBold.ttf
     - packages/flutter_gallery_assets/crane/destinations/eat_1.jpg
     - packages/flutter_gallery_assets/crane/destinations/eat_2.jpg
     - packages/flutter_gallery_assets/crane/destinations/eat_3.jpg
@@ -142,34 +142,34 @@ flutter:
     - packages/flutter_gallery_assets/fortnightly/fortnightly_stocks.png
     - packages/flutter_gallery_assets/fortnightly/fortnightly_title.png
     - packages/flutter_gallery_assets/fortnightly/fortnightly_war.png
-#    - packages/flutter_gallery_assets/reply/attachments/paris_1.jpg
-#    - packages/flutter_gallery_assets/reply/attachments/paris_2.jpg
-#    - packages/flutter_gallery_assets/reply/attachments/paris_3.jpg
-#    - packages/flutter_gallery_assets/reply/attachments/paris_4.jpg
-#    - packages/flutter_gallery_assets/reply/avatars/avatar_0.jpg
-#    - packages/flutter_gallery_assets/reply/avatars/avatar_1.jpg
-#    - packages/flutter_gallery_assets/reply/avatars/avatar_2.jpg
-#    - packages/flutter_gallery_assets/reply/avatars/avatar_3.jpg
-#    - packages/flutter_gallery_assets/reply/avatars/avatar_4.jpg
-#    - packages/flutter_gallery_assets/reply/avatars/avatar_5.jpg
-#    - packages/flutter_gallery_assets/reply/avatars/avatar_6.jpg
-#    - packages/flutter_gallery_assets/reply/avatars/avatar_7.jpg
-#    - packages/flutter_gallery_assets/reply/avatars/avatar_8.jpg
-#    - packages/flutter_gallery_assets/reply/avatars/avatar_9.jpg
-#    - packages/flutter_gallery_assets/reply/avatars/avatar_10.jpg
-#    - packages/flutter_gallery_assets/reply/avatars/avatar_express.png
-#    - packages/flutter_gallery_assets/reply/icons/twotone_add_circle_outline.png
-#    - packages/flutter_gallery_assets/reply/icons/twotone_delete.png
-#    - packages/flutter_gallery_assets/reply/icons/twotone_drafts.png
-#    - packages/flutter_gallery_assets/reply/icons/twotone_error.png
-#    - packages/flutter_gallery_assets/reply/icons/twotone_folder.png
-#    - packages/flutter_gallery_assets/reply/icons/twotone_forward.png
-#    - packages/flutter_gallery_assets/reply/icons/twotone_inbox.png
-#    - packages/flutter_gallery_assets/reply/icons/twotone_send.png
-#    - packages/flutter_gallery_assets/reply/icons/twotone_star_on_background.png
-#    - packages/flutter_gallery_assets/reply/icons/twotone_star.png
-#    - packages/flutter_gallery_assets/reply/icons/twotone_stars.png
-#    - packages/flutter_gallery_assets/reply/reply_logo.png
+    - packages/flutter_gallery_assets/reply/attachments/paris_1.jpg
+    - packages/flutter_gallery_assets/reply/attachments/paris_2.jpg
+    - packages/flutter_gallery_assets/reply/attachments/paris_3.jpg
+    - packages/flutter_gallery_assets/reply/attachments/paris_4.jpg
+    - packages/flutter_gallery_assets/reply/avatars/avatar_0.jpg
+    - packages/flutter_gallery_assets/reply/avatars/avatar_1.jpg
+    - packages/flutter_gallery_assets/reply/avatars/avatar_2.jpg
+    - packages/flutter_gallery_assets/reply/avatars/avatar_3.jpg
+    - packages/flutter_gallery_assets/reply/avatars/avatar_4.jpg
+    - packages/flutter_gallery_assets/reply/avatars/avatar_5.jpg
+    - packages/flutter_gallery_assets/reply/avatars/avatar_6.jpg
+    - packages/flutter_gallery_assets/reply/avatars/avatar_7.jpg
+    - packages/flutter_gallery_assets/reply/avatars/avatar_8.jpg
+    - packages/flutter_gallery_assets/reply/avatars/avatar_9.jpg
+    - packages/flutter_gallery_assets/reply/avatars/avatar_10.jpg
+    - packages/flutter_gallery_assets/reply/avatars/avatar_express.png
+    - packages/flutter_gallery_assets/reply/icons/twotone_add_circle_outline.png
+    - packages/flutter_gallery_assets/reply/icons/twotone_delete.png
+    - packages/flutter_gallery_assets/reply/icons/twotone_drafts.png
+    - packages/flutter_gallery_assets/reply/icons/twotone_error.png
+    - packages/flutter_gallery_assets/reply/icons/twotone_folder.png
+    - packages/flutter_gallery_assets/reply/icons/twotone_forward.png
+    - packages/flutter_gallery_assets/reply/icons/twotone_inbox.png
+    - packages/flutter_gallery_assets/reply/icons/twotone_send.png
+    - packages/flutter_gallery_assets/reply/icons/twotone_star_on_background.png
+    - packages/flutter_gallery_assets/reply/icons/twotone_star.png
+    - packages/flutter_gallery_assets/reply/icons/twotone_stars.png
+    - packages/flutter_gallery_assets/reply/reply_logo.png
     - packages/flutter_gallery_assets/places/india_chennai_flower_market.png
     - packages/flutter_gallery_assets/places/india_thanjavur_market.png
     - packages/flutter_gallery_assets/places/india_tanjore_bronze_works.png

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -90,6 +90,11 @@ flutter:
     - packages/flutter_gallery_assets/fonts/google_fonts/Montserrat-Regular.ttf
     - packages/flutter_gallery_assets/fonts/google_fonts/Rubik-Regular.ttf
     - packages/flutter_gallery_assets/fonts/google_fonts/Eczar-SemiBold.ttf
+    #- packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-Regular.ttf
+    #- packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-Medium.ttf
+    #- packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-Bold.ttf
+    #- packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-Thin.ttf
+    #- packages/flutter_gallery_assets/fonts/google_fonts/WorkSans-SemiBold.ttf
     - packages/flutter_gallery_assets/crane/destinations/eat_1.jpg
     - packages/flutter_gallery_assets/crane/destinations/eat_2.jpg
     - packages/flutter_gallery_assets/crane/destinations/eat_3.jpg


### PR DESCRIPTION
This pull request includes the following changes:
* Add a colors file with constants taken from https://material.io/design/material-studies/reply.html#color and https://github.com/material-components/material-components-android-examples/blob/develop/Reply/app/src/main/res/values/color.xml
* Adds a colorScheme and theme for Reply based on material spec and https://github.com/material-components/material-components-android-examples/blob/develop/Reply/app/src/main/res/values/themes.xml
* Adds a textTheme using WorkSans from GoogleFonts package
* Updates pubspec with new reply assets from flutter_gallery_assets
* Adds Reply Logo and FAB to navigation rail
* Adds two tone icons
* Animating arrow next to Reply logo

Before|After
---|---
![adaptive-nav](https://user-images.githubusercontent.com/948037/88444226-fc6b3f00-cdd0-11ea-879d-b24a8f134e8e.gif)| ![reply-styling](https://user-images.githubusercontent.com/948037/89625752-39ade300-d84d-11ea-8141-c13bc9fff27d.gif)
