### PR TITLE
[Reply] Fix scaffold overflow on mobile

### DIFF
--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -9,7 +9,7 @@ class InboxPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
 
-    return Center(
+    return SafeArea(
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [


### PR DESCRIPTION
This change adds a SafeArea around our ListView in our InboxPage to prevent overflow of the Scaffold beneath the status bar area.

Before|After
---|---
![Screenshot_20200811-163605](https://user-images.githubusercontent.com/948037/89959359-1a1e0e00-dbf1-11ea-8e68-a05e0883259f.png)|![Screenshot_20200811-163543](https://user-images.githubusercontent.com/948037/89959365-1d18fe80-dbf1-11ea-8056-053c99085c4a.png)

