### PR TITLE
[Reply] Implement mail view page

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -219,33 +219,31 @@ class _DesktopNavState extends State<_DesktopNav>
                                       onTap: onLogoTapped,
                                     ),
                                   ),
-                                  _isExtended
-                                      ? SizedBox(
-                                          width: 128,
-                                          child: Row(
-                                            children: [
-                                              const SizedBox(width: 36),
-                                              Align(
-                                                alignment:
-                                                    const Alignment(0, -1.5),
-                                                child: ClipOval(
-                                                  child: Image.asset(
-                                                    'reply/avatars/avatar_2.jpg',
-                                                    package: _assetsPackage,
-                                                    width: 32,
-                                                    height: 32,
-                                                  ),
-                                                ),
+                                  if (_isExtended)
+                                    SizedBox(
+                                      width: 128,
+                                      child: Row(
+                                        children: [
+                                          const SizedBox(width: 36),
+                                          Align(
+                                            alignment: const Alignment(0, -1.5),
+                                            child: ClipOval(
+                                              child: Image.asset(
+                                                'reply/avatars/avatar_2.jpg',
+                                                package: _assetsPackage,
+                                                width: 32,
+                                                height: 32,
                                               ),
-                                              const SizedBox(width: 12),
-                                              const Icon(
-                                                Icons.settings,
-                                                color: ReplyColors.blue200,
-                                              ),
-                                            ],
+                                            ),
                                           ),
-                                        )
-                                      : const SizedBox(),
+                                          const SizedBox(width: 12),
+                                          const Icon(
+                                            Icons.settings,
+                                            color: ReplyColors.blue200,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
                                 ],
                               ),
                             ),

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -8,6 +8,7 @@ class InboxPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
+    final isTablet = isDisplaySmallDesktop(context);
 
     return Navigator(
       onGenerateRoute: (settings) {
@@ -19,8 +20,8 @@ class InboxPage extends StatelessWidget {
                 Expanded(
                   child: ListView.separated(
                     padding: EdgeInsetsDirectional.only(
-                      start: isDesktop ? 120 : 6,
-                      end: isDesktop ? 120 : 6,
+                      start: isTablet ? 60 : isDesktop ? 120 : 6,
+                      end: isTablet ? 60 : isDesktop ? 120 : 6,
                       top: isDesktop ? 28 : 6,
                     ),
                     itemCount: 2,

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -9,26 +9,33 @@ class InboxPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
 
-    return SafeArea(
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: ListView.separated(
-              padding: EdgeInsetsDirectional.only(
-                start: isDesktop ? 120 : 6,
-                end: isDesktop ? 120 : 6,
-                top: isDesktop ? 28 : 6,
-              ),
-              itemCount: 2,
-              separatorBuilder: (context, index) => const SizedBox(height: 6),
-              itemBuilder: (context, index) {
-                return const MailCardPreview();
-              },
+    return Navigator(
+      onGenerateRoute: (settings) {
+        return MaterialPageRoute<void>(builder: (context) {
+          return SafeArea(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: ListView.separated(
+                    padding: EdgeInsetsDirectional.only(
+                      start: isDesktop ? 120 : 6,
+                      end: isDesktop ? 120 : 6,
+                      top: isDesktop ? 28 : 6,
+                    ),
+                    itemCount: 2,
+                    separatorBuilder: (context, index) =>
+                        const SizedBox(height: 6),
+                    itemBuilder: (context, index) {
+                      return const MailCardPreview();
+                    },
+                  ),
+                ),
+              ],
             ),
-          ),
-        ],
-      ),
+          );
+        });
+      },
     );
   }
 }

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -9,6 +9,7 @@ class InboxPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
     final isTablet = isDisplaySmallDesktop(context);
+    final horizontalPadding = isTablet ? 60.0 : isDesktop ? 120.0 : 6.0;
 
     return Navigator(
       onGenerateRoute: (settings) {
@@ -20,8 +21,8 @@ class InboxPage extends StatelessWidget {
                 Expanded(
                   child: ListView.separated(
                     padding: EdgeInsetsDirectional.only(
-                      start: isTablet ? 60 : isDesktop ? 120 : 6,
-                      end: isTablet ? 60 : isDesktop ? 120 : 6,
+                      start: horizontalPadding,
+                      end: horizontalPadding,
                       top: isDesktop ? 28 : 6,
                     ),
                     itemCount: 2,

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -100,7 +100,7 @@ class MailCardPreview extends StatelessWidget {
                           width: 36,
                         ),
                       ),
-                    )
+                    ),
                   ],
                 ),
               ),

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -35,7 +35,10 @@ class MailPreviewCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
-                      Text('Google Express - 4 hrs ago', style: textTheme.caption),
+                      Text(
+                        'Google Express - 4 hrs ago',
+                        style: textTheme.caption,
+                      ),
                       const SizedBox(height: 4),
                       Text('Package Shipped!', style: textTheme.headline6),
                       const SizedBox(height: 16),

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -35,22 +35,7 @@ class MailPreviewCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
-                      Row(
-                        children: [
-                          Text('Google Express', style: textTheme.caption),
-                          Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 4,
-                            ),
-                            child: Container(
-                              color: Colors.black,
-                              width: 12,
-                              height: 0.5,
-                            ),
-                          ),
-                          Text('15 mins ago', style: textTheme.caption),
-                        ],
-                      ),
+                      Text('Google Express - 4 hrs ago', style: textTheme.caption),
                       const SizedBox(height: 4),
                       Text('Package Shipped!', style: textTheme.headline6),
                       const SizedBox(height: 16),

--- a/lib/studies/reply/mail_view_page.dart
+++ b/lib/studies/reply/mail_view_page.dart
@@ -41,23 +41,7 @@ class MailViewPage extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
-                      Row(
-                        children: [
-                          const Text('Google Express'),
-                          Padding(
-                            padding: const EdgeInsetsDirectional.only(
-                              start: 8,
-                              end: 8,
-                            ),
-                            child: Container(
-                              height: 1,
-                              width: 8,
-                              color: Colors.black,
-                            ),
-                          ),
-                          const Text('4 hrs ago'),
-                        ],
-                      ),
+                      const Text('Google Express - 4 hrs ago'),
                       const SizedBox(height: 4),
                       Text(
                         'To Jeff,',

--- a/lib/studies/reply/mail_view_page.dart
+++ b/lib/studies/reply/mail_view_page.dart
@@ -5,10 +5,50 @@ class MailViewPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
-        child: OutlineButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('Back'),
+      body: SafeArea(
+        child: Padding(
+          padding:
+              const EdgeInsetsDirectional.only(top: 32, start: 20, end: 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Package shipped!',
+                      style: Theme.of(context).textTheme.headline4,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.keyboard_arrow_down),
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                  ),
+                ],
+              ),
+              Row(
+                children: [
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          const Text('Google Express'),
+                          Container(),
+                          const Text('4 hrs ago'),
+                        ],
+                      ),
+                      const Text('To Jeff,'),
+                    ],
+                  ),
+                ],
+              ),
+              const Text('Message'),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/studies/reply/mail_view_page.dart
+++ b/lib/studies/reply/mail_view_page.dart
@@ -80,12 +80,16 @@ class MailViewPage extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 32),
-              Text(
-                'Cucumber Mask Facial has shipped. '
-                'Keep an eye out for a package to arrive between this Thursday and next Tuesday. '
-                'If for any reason you don\'t receive your package before the end of next week, please reach out to use for details on your shipment. '
-                'As always, thank you for shopping with us and we hope you love our specially formulated Cucumber Mask!',
-                style: textTheme.bodyText2.copyWith(fontSize: 16),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Text(
+                    'Cucumber Mask Facial has shipped.\n\n'
+                    'Keep an eye out for a package to arrive between this Thursday and next Tuesday. '
+                    'If for any reason you don\'t receive your package before the end of next week, please reach out to use for details on your shipment.\n\n'
+                    'As always, thank you for shopping with us and we hope you love our specially formulated Cucumber Mask!',
+                    style: textTheme.bodyText2.copyWith(fontSize: 16),
+                  ),
+                ),
               ),
             ],
           ),

--- a/lib/studies/reply/mail_view_page.dart
+++ b/lib/studies/reply/mail_view_page.dart
@@ -1,24 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:gallery/studies/reply/colors.dart';
 
 class MailViewPage extends StatelessWidget {
   const MailViewPage({Key key}) : super(key: key);
   @override
   Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
     return Scaffold(
       body: SafeArea(
         child: Padding(
           padding:
-              const EdgeInsetsDirectional.only(top: 32, start: 20, end: 20),
+              const EdgeInsetsDirectional.only(top: 42, start: 20, end: 20),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Row(
                 children: [
                   Expanded(
                     child: Text(
                       'Package shipped!',
-                      style: Theme.of(context).textTheme.headline4,
+                      style: textTheme.headline4.copyWith(height: 1.1),
                     ),
                   ),
                   IconButton(
@@ -26,27 +28,65 @@ class MailViewPage extends StatelessWidget {
                     onPressed: () {
                       Navigator.pop(context);
                     },
+                    splashRadius: 20,
                   ),
                 ],
               ),
+              const SizedBox(height: 16),
               Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
                   Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
                       Row(
                         children: [
                           const Text('Google Express'),
-                          Container(),
+                          Padding(
+                            padding: const EdgeInsetsDirectional.only(
+                              start: 8,
+                              end: 8,
+                            ),
+                            child: Container(
+                              height: 1,
+                              width: 8,
+                              color: Colors.black,
+                            ),
+                          ),
                           const Text('4 hrs ago'),
                         ],
                       ),
-                      const Text('To Jeff,'),
+                      const SizedBox(height: 4),
+                      Text(
+                        'To Jeff,',
+                        style: textTheme.caption
+                            .copyWith(color: ReplyColors.black900Alpha060),
+                      ),
                     ],
+                  ),
+                  Transform.translate(
+                    offset: const Offset(-8, 0),
+                    child: ClipOval(
+                      child: Image.asset(
+                        'reply/avatars/avatar_0.jpg',
+                        package: 'flutter_gallery_assets',
+                        height: 36,
+                        width: 36,
+                      ),
+                    ),
                   ),
                 ],
               ),
-              const Text('Message'),
+              const SizedBox(height: 32),
+              Text(
+                'Cucumber Mask Facial has shipped. '
+                'Keep an eye out for a package to arrive between this Thursday and next Tuesday. '
+                'If for any reason you don\'t receive your package before the end of next week, please reach out to use for details on your shipment. '
+                'As always, thank you for shopping with us and we hope you love our specially formulated Cucumber Mask!',
+                style: textTheme.bodyText2.copyWith(fontSize: 16),
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
This change introduces the mail view page for Reply:
* Build out layout for page that presents an email's content e.g. MailViewPage
* Wrap InboxPage in a Navigator to allow for a persistent navigation drawer/rail or bottom app bar across screens

Mobile|Tablet|Desktop
---|---|---
![Screen Shot 2020-08-12 at 12 11 46 AM](https://user-images.githubusercontent.com/948037/89985804-72283500-dc30-11ea-888c-c5b89abdb09d.png)|![Screen Shot 2020-08-12 at 12 11 23 AM](https://user-images.githubusercontent.com/948037/89985813-75bbbc00-dc30-11ea-969e-2de6fc095fac.png)|![Screen Shot 2020-08-12 at 12 11 29 AM](https://user-images.githubusercontent.com/948037/89985824-781e1600-dc30-11ea-95cd-6cc7d2e342b4.png)



