### PR TITLE
[Reply] Contextual Animations

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -6,6 +6,8 @@ import 'package:gallery/layout/adaptive.dart';
 import 'package:gallery/studies/reply/colors.dart';
 import 'package:gallery/studies/reply/inbox.dart';
 import 'package:gallery/studies/reply/bottom_drawer.dart';
+import 'package:provider/provider.dart';
+import 'package:gallery/studies/reply/model/email_store.dart';
 
 const _assetsPackage = 'flutter_gallery_assets';
 const _iconAssetLocation = 'reply/icons';
@@ -684,11 +686,31 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
       ),
       floatingActionButton: _bottomDrawerVisible
           ? null
-          : FloatingActionButton(
-              heroTag: 'Bottom App Bar FAB',
-              child: const Icon(Icons.create),
-              onPressed: () {
-                // TODO: Implement onPressed for Bottom App Bar FAB
+          : Consumer<EmailStore>(
+              builder: (context, model, child) {
+                final showEditAsAction = model.currentlySelectedEmailId == -1;
+                return FloatingActionButton(
+                  heroTag: 'Bottom App Bar FAB',
+                  child: AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 400),
+                    transitionBuilder: (child, animation) => ScaleTransition(
+                      child: child,
+                      scale: animation,
+                    ),
+                    child: showEditAsAction
+                        ? Icon(
+                            Icons.create,
+                            key: UniqueKey(),
+                          )
+                        : Icon(
+                            Icons.reply_all,
+                            key: UniqueKey(),
+                          ),
+                  ),
+                  onPressed: () {
+                    // TODO: Implement onPressed for Bottom App Bar FAB
+                  },
+                );
               },
             ),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:gallery/data/gallery_options.dart';
 import 'package:gallery/l10n/gallery_localizations.dart';
 import 'package:gallery/layout/adaptive.dart';
@@ -389,7 +390,7 @@ class _MobileNav extends StatefulWidget {
 }
 
 class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
-  final GlobalKey _bottomDrawerKey = GlobalKey(debugLabel: 'Bottom Drawer');
+  final _bottomDrawerKey = GlobalKey(debugLabel: 'Bottom Drawer');
   int _destinationsCount;
   AnimationController _drawerController;
   AnimationController _dropArrowController;

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -715,8 +715,9 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
                                     IconButton(
                                       icon: const ImageIcon(
                                         AssetImage(
-                                            '$_iconAssetLocation/twotone_star.png',
-                                            package: _assetsPackage),
+                                          '$_iconAssetLocation/twotone_star.png',
+                                          package: _assetsPackage,
+                                        ),
                                       ),
                                       onPressed: () {},
                                       color: ReplyColors.white50,
@@ -724,8 +725,9 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
                                     IconButton(
                                       icon: const ImageIcon(
                                         AssetImage(
-                                            '$_iconAssetLocation/twotone_delete.png',
-                                            package: _assetsPackage),
+                                          '$_iconAssetLocation/twotone_delete.png',
+                                          package: _assetsPackage,
+                                        ),
                                       ),
                                       onPressed: () {},
                                       color: ReplyColors.white50,

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -646,6 +646,8 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
         child: SizedBox(
           height: kToolbarHeight,
           child: Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               InkWell(
                 borderRadius: const BorderRadius.all(Radius.circular(16)),
@@ -668,7 +670,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
                     const SizedBox(width: 10),
                     AnimatedOpacity(
                       opacity: _bottomDrawerVisible ? 0.0 : 1.0,
-                      duration: const Duration(milliseconds: 250),
+                      duration: const Duration(milliseconds: 350),
                       child: Text(
                         _currentDestination,
                         style: Theme.of(context)
@@ -679,6 +681,56 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
                     ),
                   ],
                 ),
+              ),
+              Consumer<EmailStore>(
+                builder: (context, model, child) {
+                  final showSecond = model.currentlySelectedEmailId >= 0;
+
+                  return AnimatedSize(
+                    duration: const Duration(milliseconds: 350),
+                    vsync: this,
+                    child: AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 350),
+                      transitionBuilder: (child, animation) => ScaleTransition(
+                        child: child,
+                        scale: animation,
+                      ),
+                      child: showSecond
+                          ? Row(
+                              children: [
+                                IconButton(
+                                  icon: const ImageIcon(
+                                    AssetImage(
+                                        '$_iconAssetLocation/twotone_star.png',
+                                        package: _assetsPackage),
+                                  ),
+                                  onPressed: () {},
+                                  color: ReplyColors.white50,
+                                ),
+                                IconButton(
+                                  icon: const ImageIcon(
+                                    AssetImage(
+                                        '$_iconAssetLocation/twotone_delete.png',
+                                        package: _assetsPackage),
+                                  ),
+                                  onPressed: () {},
+                                  color: ReplyColors.white50,
+                                ),
+                                IconButton(
+                                  icon: const Icon(Icons.more_vert),
+                                  onPressed: () {},
+                                  color: ReplyColors.white50,
+                                ),
+                              ],
+                            )
+                          : IconButton(
+                              icon: const Icon(Icons.search),
+                              color: ReplyColors.white50,
+                              onPressed: () {},
+                            ),
+                    ),
+                  );
+                },
               ),
             ],
           ),
@@ -692,7 +744,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
                 return FloatingActionButton(
                   heroTag: 'Bottom App Bar FAB',
                   child: AnimatedSwitcher(
-                    duration: const Duration(milliseconds: 400),
+                    duration: const Duration(milliseconds: 350),
                     transitionBuilder: (child, animation) => ScaleTransition(
                       child: child,
                       scale: animation,

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -668,23 +668,30 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
                     const SizedBox(width: 8),
                     const ReplyLogo(),
                     const SizedBox(width: 10),
-                    AnimatedOpacity(
-                      opacity: _bottomDrawerVisible ? 0.0 : 1.0,
-                      duration: const Duration(milliseconds: 350),
-                      child: Text(
-                        _currentDestination,
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodyText1
-                            .copyWith(color: ReplyColors.blue50),
-                      ),
+                    Consumer<EmailStore>(
+                      builder: (context, model, child) {
+                        final onMailView = model.currentlySelectedEmailId >= 0;
+
+                        return AnimatedOpacity(
+                          opacity:
+                              _bottomDrawerVisible | onMailView ? 0.0 : 1.0,
+                          duration: const Duration(milliseconds: 350),
+                          child: Text(
+                            _currentDestination,
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyText1
+                                .copyWith(color: ReplyColors.blue50),
+                          ),
+                        );
+                      },
                     ),
                   ],
                 ),
               ),
               Consumer<EmailStore>(
                 builder: (context, model, child) {
-                  final showSecond = model.currentlySelectedEmailId >= 0;
+                  final onMailView = model.currentlySelectedEmailId >= 0;
 
                   return AnimatedSize(
                     duration: const Duration(milliseconds: 350),
@@ -695,39 +702,46 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
                         child: child,
                         scale: animation,
                       ),
-                      child: showSecond
-                          ? Row(
-                              children: [
-                                IconButton(
-                                  icon: const ImageIcon(
-                                    AssetImage(
-                                        '$_iconAssetLocation/twotone_star.png',
-                                        package: _assetsPackage),
-                                  ),
-                                  onPressed: () {},
-                                  color: ReplyColors.white50,
-                                ),
-                                IconButton(
-                                  icon: const ImageIcon(
-                                    AssetImage(
-                                        '$_iconAssetLocation/twotone_delete.png',
-                                        package: _assetsPackage),
-                                  ),
-                                  onPressed: () {},
-                                  color: ReplyColors.white50,
-                                ),
-                                IconButton(
-                                  icon: const Icon(Icons.more_vert),
-                                  onPressed: () {},
-                                  color: ReplyColors.white50,
-                                ),
-                              ],
-                            )
-                          : IconButton(
-                              icon: const Icon(Icons.search),
+                      child: _bottomDrawerVisible
+                          ? IconButton(
+                              key: UniqueKey(),
+                              icon: const Icon(Icons.settings),
                               color: ReplyColors.white50,
                               onPressed: () {},
-                            ),
+                            )
+                          : onMailView
+                              ? Row(
+                                  children: [
+                                    IconButton(
+                                      icon: const ImageIcon(
+                                        AssetImage(
+                                            '$_iconAssetLocation/twotone_star.png',
+                                            package: _assetsPackage),
+                                      ),
+                                      onPressed: () {},
+                                      color: ReplyColors.white50,
+                                    ),
+                                    IconButton(
+                                      icon: const ImageIcon(
+                                        AssetImage(
+                                            '$_iconAssetLocation/twotone_delete.png',
+                                            package: _assetsPackage),
+                                      ),
+                                      onPressed: () {},
+                                      color: ReplyColors.white50,
+                                    ),
+                                    IconButton(
+                                      icon: const Icon(Icons.more_vert),
+                                      onPressed: () {},
+                                      color: ReplyColors.white50,
+                                    ),
+                                  ],
+                                )
+                              : IconButton(
+                                  icon: const Icon(Icons.search),
+                                  color: ReplyColors.white50,
+                                  onPressed: () {},
+                                ),
                     ),
                   );
                 },
@@ -740,7 +754,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
           ? null
           : Consumer<EmailStore>(
               builder: (context, model, child) {
-                final showEditAsAction = model.currentlySelectedEmailId == -1;
+                final onMailView = model.currentlySelectedEmailId == -1;
                 return FloatingActionButton(
                   heroTag: 'Bottom App Bar FAB',
                   child: AnimatedSwitcher(
@@ -749,7 +763,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
                       child: child,
                       scale: animation,
                     ),
-                    child: showEditAsAction
+                    child: onMailView
                         ? Icon(
                             Icons.create,
                             key: UniqueKey(),

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -20,25 +20,27 @@ class InboxPage extends StatelessWidget {
           onGenerateRoute: (settings) {
             return MaterialPageRoute<void>(builder: (context) {
               return SafeArea(
+                bottom: false,
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Expanded(
-                      child: ListView.separated(
+                      child: ListView(
                         padding: EdgeInsetsDirectional.only(
                           start: horizontalPadding,
                           end: horizontalPadding,
                           top: isDesktop ? 28 : 0,
                         ),
-                        itemCount: model.emails.length,
-                        separatorBuilder: (context, index) =>
+                        children: [
+                          for (int index = 0;
+                              index < model.emails.length;
+                              index++) ...[
+                            MailPreviewCard(
+                                id: index, email: model.emails[index]),
                             const SizedBox(height: 4),
-                        itemBuilder: (context, index) {
-                          return MailPreviewCard(
-                            id: index,
-                            email: model.emails[index],
-                          );
-                        },
+                          ],
+                          const SizedBox(height: kToolbarHeight),
+                        ],
                       ),
                     ),
                   ],

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -36,7 +36,9 @@ class InboxPage extends StatelessWidget {
                               index < model.emails.length;
                               index++) ...[
                             MailPreviewCard(
-                                id: index, email: model.emails[index]),
+                              id: index,
+                              email: model.emails[index],
+                            ),
                             const SizedBox(height: 4),
                           ],
                           const SizedBox(height: kToolbarHeight),

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -5,6 +5,8 @@ import 'package:gallery/layout/adaptive.dart';
 import 'package:gallery/studies/reply/colors.dart';
 import 'package:gallery/studies/reply/mail_view_page.dart';
 import 'package:gallery/studies/reply/model/email_model.dart';
+import 'package:gallery/studies/reply/model/email_store.dart';
+import 'package:provider/provider.dart';
 
 const _assetsPackage = 'flutter_gallery_assets';
 const _iconAssetLocation = 'reply/icons';
@@ -34,10 +36,15 @@ class MailPreviewCard extends StatelessWidget {
       closedShape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.all(Radius.circular(0)),
       ),
+      openElevation: 0,
       closedElevation: 0,
       closedBuilder: (context, openContainer) {
         return InkWell(
-          onTap: openContainer,
+          onTap: () {
+            Provider.of<EmailStore>(context, listen: false)
+                .currentlySelectedEmailId = id;
+            openContainer.call();
+          },
           child: LayoutBuilder(
             builder: (context, constraints) {
               return ConstrainedBox(
@@ -88,8 +95,10 @@ class MailPreviewCard extends StatelessWidget {
                                       color: ReplyColors.blue600,
                                     ),
                                     SizedBox(width: 20),
-                                    Icon(Icons.more_vert,
-                                        color: ReplyColors.blue700),
+                                    Icon(
+                                      Icons.more_vert,
+                                      color: ReplyColors.blue700,
+                                    ),
                                   ],
                                 ),
                               const SizedBox(width: 20),

--- a/lib/studies/reply/mail_view_page.dart
+++ b/lib/studies/reply/mail_view_page.dart
@@ -2,10 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:gallery/studies/reply/colors.dart';
 
 import 'package:gallery/studies/reply/model/email_model.dart';
+import 'package:gallery/studies/reply/model/email_store.dart';
+import 'package:provider/provider.dart';
 
 class MailViewPage extends StatelessWidget {
-  const MailViewPage({Key key, @required this.id, @required this.email})
-      : super(key: key);
+  const MailViewPage({
+    Key key,
+    @required this.id,
+    @required this.email,
+  }) : super(key: key);
 
   final int id;
   final Email email;
@@ -32,7 +37,13 @@ class MailViewPage extends StatelessWidget {
                   ),
                   IconButton(
                     icon: const Icon(Icons.keyboard_arrow_down),
-                    onPressed: () => Navigator.pop(context),
+                    onPressed: () {
+                      Provider.of<EmailStore>(
+                        context,
+                        listen: false,
+                      ).currentlySelectedEmailId = -1;
+                      Navigator.pop(context);
+                    },
                     splashRadius: 20,
                   ),
                 ],


### PR DESCRIPTION
This pull request adds contextual actions to Reply's bottom app bar and animates between the different actions.
Includes the following changes:
* Animate between row of email context actions and search launcher when MailView is on scaffold
* Animate page title away when on MailView
* Animate between compose and forward fab on bottom app bar
* Extend scaffold under bottom app bar
* Animate between settings icon and contextual actions when drawer is opened

![reply-final-contextual-anims](https://user-images.githubusercontent.com/948037/90093903-77918800-dce1-11ea-9f8c-bff0a35825fd.gif)
