### PR TITLE
[Reply] Compose page 

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -924,10 +924,10 @@ class _ReplyFab extends StatefulWidget {
   final bool onMailView;
 
   @override
-  __ReplyFabState createState() => __ReplyFabState();
+  _ReplyFabState createState() => _ReplyFabState();
 }
 
-class __ReplyFabState extends State<_ReplyFab>
+class _ReplyFabState extends State<_ReplyFab>
     with SingleTickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
@@ -964,7 +964,9 @@ class __ReplyFabState extends State<_ReplyFab>
                     Text(
                       widget.onMailView ? 'REPLY' : 'COMPOSE',
                       style: Theme.of(context).textTheme.headline5.copyWith(
-                          fontSize: 16, color: theme.colorScheme.onSecondary),
+                            fontSize: 16,
+                            color: theme.colorScheme.onSecondary,
+                          ),
                     ),
                 ],
               ),

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -963,10 +963,8 @@ class __ReplyFabState extends State<_ReplyFab>
                   if (widget.extended)
                     Text(
                       widget.onMailView ? 'REPLY' : 'COMPOSE',
-                      style: Theme.of(context)
-                          .textTheme
-                          .headline5
-                          .copyWith(fontSize: 16, color: ReplyColors.black900),
+                      style: Theme.of(context).textTheme.headline5.copyWith(
+                          fontSize: 16, color: theme.colorScheme.onSecondary),
                     ),
                 ],
               ),

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -314,12 +314,7 @@ class _NavigationRailHeader extends StatelessWidget {
             start: 12,
             end: 16,
           ),
-          child: Consumer<EmailStore>(
-            builder: (context, model, child) {
-              final onMailView = model.currentlySelectedEmailId != -1;
-              return _ReplyFab(extended: extended, onMailView: onMailView);
-            },
-          ),
+          child: _ReplyFab(extended: extended),
         ),
         const SizedBox(height: 8),
       ],
@@ -669,14 +664,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
           ),
         ),
       ),
-      floatingActionButton: _bottomDrawerVisible
-          ? null
-          : Consumer<EmailStore>(
-              builder: (context, model, child) {
-                final onMailView = model.currentlySelectedEmailId != -1;
-                return _ReplyFab(onMailView: onMailView);
-              },
-            ),
+      floatingActionButton: _bottomDrawerVisible ? null : const _ReplyFab(),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
     );
   }
@@ -917,11 +905,9 @@ class _ReplyLogo extends StatelessWidget {
 }
 
 class _ReplyFab extends StatefulWidget {
-  const _ReplyFab({this.extended = false, @required this.onMailView})
-      : assert(onMailView != null);
+  const _ReplyFab({this.extended = false});
 
   final bool extended;
-  final bool onMailView;
 
   @override
   _ReplyFabState createState() => _ReplyFabState();
@@ -944,44 +930,50 @@ class _ReplyFabState extends State<_ReplyFab>
           : const CircleBorder(),
       closedColor: theme.colorScheme.secondary,
       closedBuilder: (context, openContainer) {
-        if (isDesktop) {
-          return AnimatedSize(
-            vsync: this,
-            curve: Curves.easeInOut,
-            duration: kThemeAnimationDuration,
-            child: FloatingActionButton.extended(
-              heroTag: 'Rail FAB',
-              tooltip: widget.onMailView ? 'Reply' : 'Compose',
-              isExtended: widget.extended,
-              onPressed: openContainer,
-              label: Row(
-                children: [
-                  _FabSwitcher(
-                    onMailView: widget.onMailView,
+        return Consumer<EmailStore>(
+          builder: (context, model, child) {
+            final onMailView = model.currentlySelectedEmailId != -1;
+
+            if (isDesktop) {
+              return AnimatedSize(
+                vsync: this,
+                curve: Curves.easeInOut,
+                duration: kThemeAnimationDuration,
+                child: FloatingActionButton.extended(
+                  heroTag: 'Rail FAB',
+                  tooltip: onMailView ? 'Reply' : 'Compose',
+                  isExtended: widget.extended,
+                  onPressed: openContainer,
+                  label: Row(
+                    children: [
+                      _FabSwitcher(
+                        onMailView: onMailView,
+                      ),
+                      SizedBox(width: widget.extended ? 16 : 0),
+                      if (widget.extended)
+                        Text(
+                          onMailView ? 'REPLY' : 'COMPOSE',
+                          style: Theme.of(context).textTheme.headline5.copyWith(
+                                fontSize: 16,
+                                color: theme.colorScheme.onSecondary,
+                              ),
+                        ),
+                    ],
                   ),
-                  SizedBox(width: widget.extended ? 16 : 0),
-                  if (widget.extended)
-                    Text(
-                      widget.onMailView ? 'REPLY' : 'COMPOSE',
-                      style: Theme.of(context).textTheme.headline5.copyWith(
-                            fontSize: 16,
-                            color: theme.colorScheme.onSecondary,
-                          ),
-                    ),
-                ],
-              ),
-            ),
-          );
-        } else {
-          return FloatingActionButton(
-            heroTag: 'Bottom App Bar FAB',
-            tooltip: widget.onMailView ? 'Reply' : 'Compose',
-            child: _FabSwitcher(
-              onMailView: widget.onMailView,
-            ),
-            onPressed: openContainer,
-          );
-        }
+                ),
+              );
+            } else {
+              return FloatingActionButton(
+                heroTag: 'Bottom App Bar FAB',
+                tooltip: onMailView ? 'Reply' : 'Compose',
+                child: _FabSwitcher(
+                  onMailView: onMailView,
+                ),
+                onPressed: openContainer,
+              );
+            }
+          },
+        );
       },
     );
   }

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -80,6 +80,11 @@ ThemeData _buildReplyLightTheme(BuildContext context) {
       background: ReplyColors.blue50,
     ),
     cardColor: ReplyColors.white50,
+    chipTheme: _buildChipTheme(
+      ReplyColors.blue700,
+      ReplyColors.lightChipBackground,
+      Brightness.light,
+    ),
     canvasColor: ReplyColors.white50,
     accentColor: ReplyColors.orange500,
     textTheme: _buildReplyLightTextTheme(base.textTheme),
@@ -123,9 +128,33 @@ ThemeData _buildReplyDarkTheme(BuildContext context) {
       background: ReplyColors.black900Alpha087,
     ),
     cardColor: ReplyColors.darkCardBackground,
+    chipTheme: _buildChipTheme(
+      ReplyColors.blue200,
+      ReplyColors.darkChipBackground,
+      Brightness.dark,
+    ),
     canvasColor: ReplyColors.black900,
     accentColor: ReplyColors.orange300,
     textTheme: _buildReplyDarkTextTheme(base.textTheme),
+  );
+}
+
+ChipThemeData _buildChipTheme(
+    Color primaryColor, Color chipBackground, Brightness brightness) {
+  return ChipThemeData(
+    backgroundColor: primaryColor.withOpacity(0.12),
+    disabledColor: primaryColor.withOpacity(0.87),
+    selectedColor: primaryColor.withOpacity(0.05),
+    secondarySelectedColor: chipBackground,
+    padding: const EdgeInsets.all(4),
+    shape: const StadiumBorder(),
+    labelStyle: GoogleFonts.workSansTextTheme().bodyText2.copyWith(
+          color: brightness == Brightness.dark
+              ? ReplyColors.white50
+              : ReplyColors.black900,
+        ),
+    secondaryLabelStyle: GoogleFonts.workSansTextTheme().bodyText2.copyWith(),
+    brightness: brightness,
   );
 }
 

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -140,7 +140,10 @@ ThemeData _buildReplyDarkTheme(BuildContext context) {
 }
 
 ChipThemeData _buildChipTheme(
-    Color primaryColor, Color chipBackground, Brightness brightness) {
+  Color primaryColor,
+  Color chipBackground,
+  Brightness brightness,
+) {
   return ChipThemeData(
     backgroundColor: primaryColor.withOpacity(0.12),
     disabledColor: primaryColor.withOpacity(0.87),
@@ -153,7 +156,7 @@ ChipThemeData _buildChipTheme(
               ? ReplyColors.white50
               : ReplyColors.black900,
         ),
-    secondaryLabelStyle: GoogleFonts.workSansTextTheme().bodyText2.copyWith(),
+    secondaryLabelStyle: GoogleFonts.workSansTextTheme().bodyText2,
     brightness: brightness,
   );
 }

--- a/lib/studies/reply/colors.dart
+++ b/lib/studies/reply/colors.dart
@@ -33,4 +33,6 @@ class ReplyColors {
   static const Color darkBottomAppBarBackground = Color(0xFF2D2D2D);
   static const Color darkDrawerBackground = Color(0xFF353535);
   static const Color darkCardBackground = Color(0xFF1E1E1E);
+  static const Color darkChipBackground = Color(0xFF2A2A2A);
+  static const Color lightChipBackground = Color(0xFFE5E5E5);
 }

--- a/lib/studies/reply/compose_page.dart
+++ b/lib/studies/reply/compose_page.dart
@@ -75,10 +75,10 @@ class _SubjectRow extends StatefulWidget {
   final String subject;
 
   @override
-  __SubjectRowState createState() => __SubjectRowState();
+  _SubjectRowState createState() => _SubjectRowState();
 }
 
-class __SubjectRowState extends State<_SubjectRow> {
+class _SubjectRowState extends State<_SubjectRow> {
   TextEditingController _subjectController;
 
   @override

--- a/lib/studies/reply/compose_page.dart
+++ b/lib/studies/reply/compose_page.dart
@@ -25,7 +25,7 @@ class ComposePage extends StatelessWidget {
     return Scaffold(
       body: SafeArea(
         bottom: false,
-        child: SizedBox(
+        child: Container(
           height: double.infinity,
           child: Material(
             color: Theme.of(context).cardColor,

--- a/lib/studies/reply/compose_page.dart
+++ b/lib/studies/reply/compose_page.dart
@@ -230,8 +230,6 @@ class _RecipientsRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 12),
       child: Row(

--- a/lib/studies/reply/compose_page.dart
+++ b/lib/studies/reply/compose_page.dart
@@ -221,8 +221,10 @@ class __SenderAddressRowState extends State<_SenderAddressRow> {
 }
 
 class _RecipientsRow extends StatelessWidget {
-  const _RecipientsRow({@required this.recipients, @required this.avatar})
-      : assert(recipients != null),
+  const _RecipientsRow({
+    @required this.recipients,
+    @required this.avatar,
+  })  : assert(recipients != null),
         assert(avatar != null);
 
   final String recipients;
@@ -257,9 +259,9 @@ class _RecipientsRow extends StatelessWidget {
           ),
           InkResponse(
             customBorder: const CircleBorder(),
-            child: const Icon(Icons.add_circle_outline),
             onTap: () {},
             radius: 24,
+            child: const Icon(Icons.add_circle_outline),
           ),
         ],
       ),

--- a/lib/studies/reply/compose_page.dart
+++ b/lib/studies/reply/compose_page.dart
@@ -1,0 +1,279 @@
+import 'package:flutter/material.dart';
+import 'package:gallery/studies/reply/model/email_store.dart';
+import 'package:provider/provider.dart';
+
+class ComposePage extends StatelessWidget {
+  const ComposePage();
+
+  @override
+  Widget build(BuildContext context) {
+    var _senderEmail = 'flutterfan@gmail.com';
+    var _subject = '';
+    var _recipient = 'Recipient';
+    var _recipientAvatar = 'reply/avatars/avatar_0.jpg';
+
+    final emailStore = Provider.of<EmailStore>(context);
+
+    if (emailStore.currentlySelectedEmailId >= 0) {
+      final currentEmail =
+          emailStore.emails[emailStore.currentlySelectedEmailId];
+      _subject = currentEmail.subject;
+      _recipient = currentEmail.sender;
+      _recipientAvatar = currentEmail.avatar;
+    }
+
+    return Scaffold(
+      body: SafeArea(
+        bottom: false,
+        child: Container(
+          height: double.infinity,
+          color: Theme.of(context).cardColor,
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _SubjectRow(
+                  subject: _subject,
+                ),
+                const _SectionDivider(),
+                _SenderAddressRow(
+                  senderEmail: _senderEmail,
+                ),
+                const _SectionDivider(),
+                _RecipientsRow(
+                  recipients: _recipient,
+                  avatar: _recipientAvatar,
+                ),
+                const _SectionDivider(),
+                Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: TextField(
+                    minLines: 6,
+                    maxLines: 20,
+                    decoration: const InputDecoration.collapsed(
+                      hintText: 'New Message...',
+                    ),
+                    autofocus: false,
+                    style: Theme.of(context).textTheme.bodyText2,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SubjectRow extends StatefulWidget {
+  const _SubjectRow({@required this.subject}) : assert(subject != null);
+
+  final String subject;
+
+  @override
+  __SubjectRowState createState() => __SubjectRowState();
+}
+
+class __SubjectRowState extends State<_SubjectRow> {
+  TextEditingController _subjectController;
+
+  @override
+  void initState() {
+    super.initState();
+    _subjectController = TextEditingController(text: widget.subject);
+  }
+
+  @override
+  void dispose() {
+    _subjectController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          IconButton(
+            onPressed: () => Navigator.of(context).pop(),
+            icon: Icon(
+              Icons.close,
+              color: colorScheme.onSurface,
+            ),
+          ),
+          Expanded(
+            child: TextField(
+              controller: _subjectController,
+              maxLines: 1,
+              autofocus: false,
+              style: theme.textTheme.headline6,
+              decoration: InputDecoration.collapsed(
+                hintText: 'Subject',
+                hintStyle: theme.textTheme.headline6.copyWith(
+                  color: theme.colorScheme.primary.withOpacity(0.5),
+                ),
+              ),
+            ),
+          ),
+          IconButton(
+            onPressed: () => Navigator.of(context).pop(),
+            icon: IconButton(
+              icon: ImageIcon(
+                const AssetImage(
+                  'reply/icons/twotone_send.png',
+                  package: 'flutter_gallery_assets',
+                ),
+                color: colorScheme.onSurface,
+              ),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SenderAddressRow extends StatefulWidget {
+  _SenderAddressRow({@required this.senderEmail}) : assert(senderEmail != null);
+
+  final String senderEmail;
+
+  @override
+  __SenderAddressRowState createState() => __SenderAddressRowState();
+}
+
+class __SenderAddressRowState extends State<_SenderAddressRow> {
+  String senderEmail;
+
+  @override
+  void initState() {
+    super.initState();
+    senderEmail = widget.senderEmail;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final accounts = [
+      'flutterfan@gmail.com',
+      'materialfan@gmail.com',
+    ];
+
+    return PopupMenuButton<String>(
+      padding: EdgeInsets.zero,
+      onSelected: (email) {
+        setState(() {
+          senderEmail = email;
+        });
+      },
+      itemBuilder: (context) => <PopupMenuItem<String>>[
+        PopupMenuItem<String>(
+          value: accounts[0],
+          child: Text(
+            'from.${accounts[0]}',
+            style: textTheme.bodyText2,
+          ),
+        ),
+        PopupMenuItem<String>(
+          value: accounts[1],
+          child: Text(
+            'from.${accounts[1]}',
+            style: textTheme.bodyText2,
+          ),
+        ),
+      ],
+      child: Padding(
+        padding: const EdgeInsets.only(
+          left: 12,
+          top: 16,
+          right: 10,
+          bottom: 10,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(
+              child: Text(
+                senderEmail,
+                style: textTheme.bodyText2,
+              ),
+            ),
+            Icon(
+              Icons.arrow_drop_down,
+              color: theme.colorScheme.onSurface,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RecipientsRow extends StatelessWidget {
+  const _RecipientsRow({@required this.recipients, @required this.avatar})
+      : assert(recipients != null),
+        assert(avatar != null);
+
+  final String recipients;
+  final String avatar;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Wrap(
+              children: [
+                Chip(
+                  backgroundColor:
+                      Theme.of(context).chipTheme.secondarySelectedColor,
+                  padding: EdgeInsets.zero,
+                  avatar: CircleAvatar(
+                    backgroundImage: AssetImage(
+                      '$avatar',
+                      package: 'flutter_gallery_assets',
+                    ),
+                  ),
+                  label: Text(
+                    recipients,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Icon(
+            Icons.add_circle_outline,
+            color: theme.colorScheme.onSurface,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionDivider extends StatelessWidget {
+  const _SectionDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Divider(
+      thickness: 1.1,
+      indent: 10,
+      endIndent: 10,
+    );
+  }
+}

--- a/lib/studies/reply/compose_page.dart
+++ b/lib/studies/reply/compose_page.dart
@@ -25,40 +25,42 @@ class ComposePage extends StatelessWidget {
     return Scaffold(
       body: SafeArea(
         bottom: false,
-        child: Container(
+        child: SizedBox(
           height: double.infinity,
-          color: Theme.of(context).cardColor,
-          child: SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                _SubjectRow(
-                  subject: _subject,
-                ),
-                const _SectionDivider(),
-                _SenderAddressRow(
-                  senderEmail: _senderEmail,
-                ),
-                const _SectionDivider(),
-                _RecipientsRow(
-                  recipients: _recipient,
-                  avatar: _recipientAvatar,
-                ),
-                const _SectionDivider(),
-                Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: TextField(
-                    minLines: 6,
-                    maxLines: 20,
-                    decoration: const InputDecoration.collapsed(
-                      hintText: 'New Message...',
-                    ),
-                    autofocus: false,
-                    style: Theme.of(context).textTheme.bodyText2,
+          child: Material(
+            color: Theme.of(context).cardColor,
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _SubjectRow(
+                    subject: _subject,
                   ),
-                ),
-              ],
+                  const _SectionDivider(),
+                  _SenderAddressRow(
+                    senderEmail: _senderEmail,
+                  ),
+                  const _SectionDivider(),
+                  _RecipientsRow(
+                    recipients: _recipient,
+                    avatar: _recipientAvatar,
+                  ),
+                  const _SectionDivider(),
+                  Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: TextField(
+                      minLines: 6,
+                      maxLines: 20,
+                      decoration: const InputDecoration.collapsed(
+                        hintText: 'New Message...',
+                      ),
+                      autofocus: false,
+                      style: Theme.of(context).textTheme.bodyText2,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -179,14 +181,14 @@ class __SenderAddressRowState extends State<_SenderAddressRow> {
         PopupMenuItem<String>(
           value: accounts[0],
           child: Text(
-            'from.${accounts[0]}',
+            accounts[0],
             style: textTheme.bodyText2,
           ),
         ),
         PopupMenuItem<String>(
           value: accounts[1],
           child: Text(
-            'from.${accounts[1]}',
+            accounts[1],
             style: textTheme.bodyText2,
           ),
         ),
@@ -255,9 +257,11 @@ class _RecipientsRow extends StatelessWidget {
               ],
             ),
           ),
-          Icon(
-            Icons.add_circle_outline,
-            color: theme.colorScheme.onSurface,
+          InkResponse(
+            customBorder: const CircleBorder(),
+            child: const Icon(Icons.add_circle_outline),
+            onTap: () {},
+            radius: 24,
           ),
         ],
       ),


### PR DESCRIPTION
This change implements the compose/reply page, and introduces a contextual fab for desktop/tablets. 
* Use open container transform to transition between fab and compose/reply page
* Abstract AnimatedSwitcher logic that was animating between fabs to `_FabSwitcher` class to reuse in all types of navigation layouts 
* Use `AnimatedSize` to wrap Navigation Rail FAB, animating its change of size when it changes context's

Desktop|Mobile
---|---
![reply-compose-desktop](https://user-images.githubusercontent.com/948037/90327776-0f92aa00-df4c-11ea-8e76-590f0366ac01.gif)|![reply-compose-mobile](https://user-images.githubusercontent.com/948037/90327752-c0e51000-df4b-11ea-8d3a-a392982a4e4a.gif)
