### PR TITLE
[Reply] Search page

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
 import 'package:gallery/data/gallery_options.dart';
 import 'package:gallery/l10n/gallery_localizations.dart';
@@ -9,6 +10,7 @@ import 'package:gallery/studies/reply/colors.dart';
 import 'package:gallery/studies/reply/inbox.dart';
 import 'package:gallery/studies/reply/model/email_store.dart';
 import 'package:gallery/studies/reply/profile_avatar.dart';
+import 'package:gallery/studies/reply/search_page.dart';
 import 'package:provider/provider.dart';
 
 const _assetsPackage = 'flutter_gallery_assets';
@@ -683,6 +685,22 @@ class _BottomAppBarActionItems extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Route _createSearchRoute() {
+      return PageRouteBuilder<void>(
+        pageBuilder: (context, animation, secondaryAnimation) =>
+            const SearchPage(),
+        transitionsBuilder: (context, animation, secondaryAnimation, child) {
+          return SharedAxisTransition(
+            fillColor: Theme.of(context).cardColor,
+            transitionType: SharedAxisTransitionType.scaled,
+            child: child,
+            animation: animation,
+            secondaryAnimation: secondaryAnimation,
+          );
+        },
+      );
+    }
+
     return Consumer<EmailStore>(
       builder: (context, model, child) {
         final onMailView = model.currentlySelectedEmailId >= 0;
@@ -747,7 +765,9 @@ class _BottomAppBarActionItems extends StatelessWidget {
                         IconButton(
                           icon: const Icon(Icons.search),
                           color: ReplyColors.white50,
-                          onPressed: () {},
+                          onPressed: () => Navigator.of(context).push<void>(
+                            _createSearchRoute(),
+                          ),
                         ),
                       ],
                     ),

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -748,10 +748,12 @@ class _BottomAppBarActionItems extends StatelessWidget {
                         IconButton(
                           icon: const Icon(Icons.search),
                           color: ReplyColors.white50,
-                          onPressed: () => Navigator.pushNamed(
-                            context,
-                            ReplyApp.searchRoute,
-                          ),
+                          onPressed: () {
+                            Navigator.pushNamed(
+                              context,
+                              ReplyApp.searchRoute,
+                            );
+                          },
                         ),
                       ],
                     ),

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -21,6 +21,22 @@ const double _kFlingVelocity = 2.0;
 class AdaptiveNav extends StatefulWidget {
   const AdaptiveNav({Key key}) : super(key: key);
 
+  static Route createSearchRoute() {
+    return PageRouteBuilder<void>(
+      pageBuilder: (context, animation, secondaryAnimation) =>
+          const SearchPage(),
+      transitionsBuilder: (context, animation, secondaryAnimation, child) {
+        return SharedAxisTransition(
+          fillColor: Theme.of(context).cardColor,
+          transitionType: SharedAxisTransitionType.scaled,
+          child: child,
+          animation: animation,
+          secondaryAnimation: secondaryAnimation,
+        );
+      },
+    );
+  }
+
   @override
   _AdaptiveNavState createState() => _AdaptiveNavState();
 }
@@ -685,22 +701,6 @@ class _BottomAppBarActionItems extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Route _createSearchRoute() {
-      return PageRouteBuilder<void>(
-        pageBuilder: (context, animation, secondaryAnimation) =>
-            const SearchPage(),
-        transitionsBuilder: (context, animation, secondaryAnimation, child) {
-          return SharedAxisTransition(
-            fillColor: Theme.of(context).cardColor,
-            transitionType: SharedAxisTransitionType.scaled,
-            child: child,
-            animation: animation,
-            secondaryAnimation: secondaryAnimation,
-          );
-        },
-      );
-    }
-
     return Consumer<EmailStore>(
       builder: (context, model, child) {
         final onMailView = model.currentlySelectedEmailId >= 0;
@@ -766,7 +766,7 @@ class _BottomAppBarActionItems extends StatelessWidget {
                           icon: const Icon(Icons.search),
                           color: ReplyColors.white50,
                           onPressed: () => Navigator.of(context).push<void>(
-                            _createSearchRoute(),
+                            AdaptiveNav.createSearchRoute(),
                           ),
                         ),
                       ],

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -1,16 +1,15 @@
 import 'dart:math' as math;
 
-import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
 import 'package:gallery/data/gallery_options.dart';
 import 'package:gallery/l10n/gallery_localizations.dart';
 import 'package:gallery/layout/adaptive.dart';
+import 'package:gallery/studies/reply/app.dart';
 import 'package:gallery/studies/reply/bottom_drawer.dart';
 import 'package:gallery/studies/reply/colors.dart';
 import 'package:gallery/studies/reply/inbox.dart';
 import 'package:gallery/studies/reply/model/email_store.dart';
 import 'package:gallery/studies/reply/profile_avatar.dart';
-import 'package:gallery/studies/reply/search_page.dart';
 import 'package:provider/provider.dart';
 
 const _assetsPackage = 'flutter_gallery_assets';
@@ -20,22 +19,6 @@ const double _kFlingVelocity = 2.0;
 
 class AdaptiveNav extends StatefulWidget {
   const AdaptiveNav({Key key}) : super(key: key);
-
-  static Route createSearchRoute() {
-    return PageRouteBuilder<void>(
-      pageBuilder: (context, animation, secondaryAnimation) =>
-          const SearchPage(),
-      transitionsBuilder: (context, animation, secondaryAnimation, child) {
-        return SharedAxisTransition(
-          fillColor: Theme.of(context).cardColor,
-          transitionType: SharedAxisTransitionType.scaled,
-          child: child,
-          animation: animation,
-          secondaryAnimation: secondaryAnimation,
-        );
-      },
-    );
-  }
 
   @override
   _AdaptiveNavState createState() => _AdaptiveNavState();
@@ -765,8 +748,9 @@ class _BottomAppBarActionItems extends StatelessWidget {
                         IconButton(
                           icon: const Icon(Icons.search),
                           color: ReplyColors.white50,
-                          onPressed: () => Navigator.of(context).push<void>(
-                            AdaptiveNav.createSearchRoute(),
+                          onPressed: () => Navigator.pushNamed(
+                            context,
+                            ReplyApp.searchRoute,
                           ),
                         ),
                       ],

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -47,38 +47,31 @@ class ReplyApp extends StatelessWidget {
         onGenerateRoute: (settings) {
           switch (settings.name) {
             case homeRoute:
-              {
-                return MaterialPageRoute<void>(
-                  builder: (context) {
-                    return const AdaptiveNav();
-                  },
-                );
-              }
+              return MaterialPageRoute<void>(
+                builder: (context) {
+                  return const AdaptiveNav();
+                },
+              );
               break;
             case searchRoute:
-              {
-                return PageRouteBuilder<void>(
-                  pageBuilder: (context, animation, secondaryAnimation) =>
-                      const SearchPage(),
-                  transitionsBuilder:
-                      (context, animation, secondaryAnimation, child) {
-                    return SharedAxisTransition(
-                      fillColor: Theme.of(context).cardColor,
-                      transitionType: SharedAxisTransitionType.scaled,
-                      child: child,
-                      animation: animation,
-                      secondaryAnimation: secondaryAnimation,
-                    );
-                  },
-                );
-              }
-              break;
-            default:
-              {
-                return null;
-              }
+              return PageRouteBuilder<void>(
+                pageBuilder: (context, animation, secondaryAnimation) {
+                  return const SearchPage();
+                },
+                transitionsBuilder:
+                    (context, animation, secondaryAnimation, child) {
+                  return SharedAxisTransition(
+                    fillColor: Theme.of(context).cardColor,
+                    transitionType: SharedAxisTransitionType.scaled,
+                    child: child,
+                    animation: animation,
+                    secondaryAnimation: secondaryAnimation,
+                  );
+                },
+              );
               break;
           }
+          return null;
         },
       ),
     );

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -1,3 +1,4 @@
+import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
 import 'package:gallery/data/gallery_options.dart';
 import 'package:gallery/l10n/gallery_localizations.dart';
@@ -5,13 +6,17 @@ import 'package:gallery/layout/letter_spacing.dart';
 import 'package:gallery/studies/reply/adaptive_nav.dart';
 import 'package:gallery/studies/reply/colors.dart';
 import 'package:gallery/studies/reply/model/email_store.dart';
+import 'package:gallery/studies/reply/search_page.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
+
+final rootNavKey = GlobalKey<NavigatorState>();
 
 class ReplyApp extends StatelessWidget {
   const ReplyApp();
 
   static const String homeRoute = '/reply';
+  static const String searchRoute = '/search';
 
   @override
   Widget build(BuildContext context) {
@@ -28,6 +33,7 @@ class ReplyApp extends StatelessWidget {
         ChangeNotifierProvider<EmailStore>.value(value: EmailStore()),
       ],
       child: MaterialApp(
+        navigatorKey: rootNavKey,
         title: 'Reply',
         debugShowCheckedModeBanner: false,
         theme: replyTheme,
@@ -37,6 +43,42 @@ class ReplyApp extends StatelessWidget {
         initialRoute: homeRoute,
         routes: <String, WidgetBuilder>{
           homeRoute: (context) => const AdaptiveNav(),
+        },
+        onGenerateRoute: (settings) {
+          switch (settings.name) {
+            case homeRoute:
+              {
+                return MaterialPageRoute<void>(
+                  builder: (context) {
+                    return const AdaptiveNav();
+                  },
+                );
+              }
+              break;
+            case searchRoute:
+              {
+                return PageRouteBuilder<void>(
+                  pageBuilder: (context, animation, secondaryAnimation) =>
+                      const SearchPage(),
+                  transitionsBuilder:
+                      (context, animation, secondaryAnimation, child) {
+                    return SharedAxisTransition(
+                      fillColor: Theme.of(context).cardColor,
+                      transitionType: SharedAxisTransitionType.scaled,
+                      child: child,
+                      animation: animation,
+                      secondaryAnimation: secondaryAnimation,
+                    );
+                  },
+                );
+              }
+              break;
+            default:
+              {
+                return null;
+              }
+              break;
+          }
         },
       ),
     );

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -48,9 +48,7 @@ class ReplyApp extends StatelessWidget {
           switch (settings.name) {
             case homeRoute:
               return MaterialPageRoute<void>(
-                builder: (context) {
-                  return const AdaptiveNav();
-                },
+                builder: (context) => const AdaptiveNav(),
               );
               break;
             case searchRoute:

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -16,7 +16,7 @@ class ReplyApp extends StatelessWidget {
   const ReplyApp();
 
   static const String homeRoute = '/reply';
-  static const String searchRoute = '/search';
+  static const String searchRoute = '/reply/search';
 
   @override
   Widget build(BuildContext context) {

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:gallery/layout/adaptive.dart';
+import 'package:gallery/studies/reply/adaptive_nav.dart';
 import 'package:gallery/studies/reply/mail_card_preview.dart';
 import 'package:gallery/studies/reply/model/email_store.dart';
 import 'package:provider/provider.dart';
@@ -11,7 +12,8 @@ class InboxPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
     final isTablet = isDisplaySmallDesktop(context);
-    final horizontalPadding = isTablet ? 60.0 : isDesktop ? 120.0 : 4.0;
+    final startPadding = isTablet ? 60.0 : isDesktop ? 120.0 : 4.0;
+    final endPadding = isTablet ? 30.0 : isDesktop ? 60.0 : 4.0;
 
     return Consumer<EmailStore>(
       builder: (context, model, child) {
@@ -23,8 +25,8 @@ class InboxPage extends StatelessWidget {
               Expanded(
                 child: ListView(
                   padding: EdgeInsetsDirectional.only(
-                    start: horizontalPadding,
-                    end: horizontalPadding,
+                    start: startPadding,
+                    end: endPadding,
                     top: isDesktop ? 28 : 0,
                   ),
                   children: [
@@ -41,6 +43,22 @@ class InboxPage extends StatelessWidget {
                   ],
                 ),
               ),
+              if (isDesktop) ...[
+                Padding(
+                  padding: const EdgeInsetsDirectional.only(top: 14),
+                  child: Row(
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.search),
+                        onPressed: () => Navigator.of(context).push<void>(
+                          AdaptiveNav.createSearchRoute(),
+                        ),
+                      ),
+                      SizedBox(width: isTablet ? 30 : 60),
+                    ],
+                  ),
+                ),
+              ]
             ],
           ),
         );

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:gallery/layout/adaptive.dart';
-import 'package:gallery/studies/reply/adaptive_nav.dart';
+import 'package:gallery/studies/reply/app.dart';
 import 'package:gallery/studies/reply/mail_card_preview.dart';
 import 'package:gallery/studies/reply/model/email_store.dart';
 import 'package:provider/provider.dart';
@@ -50,8 +50,8 @@ class InboxPage extends StatelessWidget {
                     children: [
                       IconButton(
                         icon: const Icon(Icons.search),
-                        onPressed: () => Navigator.of(context).push<void>(
-                          AdaptiveNav.createSearchRoute(),
+                        onPressed: () => rootNavKey.currentState.pushNamed(
+                          ReplyApp.searchRoute,
                         ),
                       ),
                       SizedBox(width: isTablet ? 30 : 60),

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -50,9 +50,11 @@ class InboxPage extends StatelessWidget {
                     children: [
                       IconButton(
                         icon: const Icon(Icons.search),
-                        onPressed: () => rootNavKey.currentState.pushNamed(
-                          ReplyApp.searchRoute,
-                        ),
+                        onPressed: () {
+                          rootNavKey.currentState.pushNamed(
+                            ReplyApp.searchRoute,
+                          );
+                        },
                       ),
                       SizedBox(width: isTablet ? 30 : 60),
                     ],

--- a/lib/studies/reply/search_page.dart
+++ b/lib/studies/reply/search_page.dart
@@ -81,7 +81,9 @@ class SearchPage extends StatelessWidget {
 }
 
 class _SectionHeader extends StatelessWidget {
-  const _SectionHeader({@required this.title}) : assert(title != null);
+  const _SectionHeader({
+    @required this.title,
+  }) : assert(title != null);
   final String title;
 
   @override

--- a/lib/studies/reply/search_page.dart
+++ b/lib/studies/reply/search_page.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+
+class SearchPage extends StatelessWidget {
+  const SearchPage();
+
+  @override
+  Widget build(BuildContext context) {
+    final splashRadius = 24.0;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Material(
+          color: Theme.of(context).cardColor,
+          child: Column(
+            children: [
+              Row(
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.arrow_back),
+                    onPressed: () => Navigator.of(context).pop(),
+                    splashRadius: splashRadius,
+                  ),
+                  const Expanded(
+                    child: TextField(
+                      decoration: InputDecoration.collapsed(
+                        hintText: 'Search email',
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.mic),
+                    onPressed: () {},
+                    splashRadius: splashRadius,
+                  )
+                ],
+              ),
+              const Divider(
+                thickness: 1.1,
+              ),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: const [
+                      _SectionHeader(title: 'YESTERDAY'),
+                      _SearchHistoryTile(
+                        search: '481 Van Brunt Street',
+                        address: 'Brooklyn, NY',
+                      ),
+                      _SearchHistoryTile(
+                        icon: Icons.home,
+                        search: 'Home',
+                        address: '199 Pacific Street, Brooklyn, NY',
+                      ),
+                      _SectionHeader(title: 'THIS WEEK'),
+                      _SearchHistoryTile(
+                        search: 'BEP GA',
+                        address: 'Forsyth Street, New York, NY',
+                      ),
+                      _SearchHistoryTile(
+                        search: 'Sushi Nakazawa',
+                        address: 'Commerce Street, New York, NY',
+                      ),
+                      _SearchHistoryTile(
+                        search: 'IFC Center',
+                        address: '6th Avenue, New York, NY',
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({@required this.title}) : assert(title != null);
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(
+        start: 16,
+        top: 16,
+        bottom: 16,
+      ),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.button,
+      ),
+    );
+  }
+}
+
+class _SearchHistoryTile extends StatelessWidget {
+  const _SearchHistoryTile({
+    this.icon = Icons.access_time,
+    @required this.search,
+    @required this.address,
+  })  : assert(search != null),
+        assert(address != null);
+
+  final IconData icon;
+  final String search;
+  final String address;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(search),
+      subtitle: Text(address),
+      onTap: () {},
+    );
+  }
+}

--- a/lib/studies/reply/search_page.dart
+++ b/lib/studies/reply/search_page.dart
@@ -10,35 +10,36 @@ class SearchPage extends StatelessWidget {
     return Scaffold(
       body: SafeArea(
         child: Material(
-          color: Theme.of(context).cardColor,
+          color: Theme.of(context).colorScheme.surface,
           child: Column(
             children: [
-              Row(
-                mainAxisSize: MainAxisSize.max,
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  IconButton(
-                    icon: const Icon(Icons.arrow_back),
-                    onPressed: () => Navigator.of(context).pop(),
-                    splashRadius: splashRadius,
-                  ),
-                  const Expanded(
-                    child: TextField(
-                      decoration: InputDecoration.collapsed(
-                        hintText: 'Search email',
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Row(
+                  mainAxisSize: MainAxisSize.max,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.arrow_back),
+                      onPressed: () => Navigator.of(context).pop(),
+                      splashRadius: splashRadius,
+                    ),
+                    const Expanded(
+                      child: TextField(
+                        decoration: InputDecoration.collapsed(
+                          hintText: 'Search email',
+                        ),
                       ),
                     ),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.mic),
-                    onPressed: () {},
-                    splashRadius: splashRadius,
-                  )
-                ],
+                    IconButton(
+                      icon: const Icon(Icons.mic),
+                      onPressed: () {},
+                      splashRadius: splashRadius,
+                    )
+                  ],
+                ),
               ),
-              const Divider(
-                thickness: 1.1,
-              ),
+              const Divider(thickness: 1.1),
               Expanded(
                 child: SingleChildScrollView(
                   child: Column(

--- a/lib/studies/reply/search_page.dart
+++ b/lib/studies/reply/search_page.dart
@@ -5,8 +5,6 @@ class SearchPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final splashRadius = 24.0;
-
     return Scaffold(
       body: SafeArea(
         child: Material(
@@ -14,15 +12,13 @@ class SearchPage extends StatelessWidget {
           child: Column(
             children: [
               Padding(
-                padding: const EdgeInsets.all(8.0),
+                padding: const EdgeInsets.all(8),
                 child: Row(
                   mainAxisSize: MainAxisSize.max,
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    IconButton(
-                      icon: const Icon(Icons.arrow_back),
+                    BackButton(
                       onPressed: () => Navigator.of(context).pop(),
-                      splashRadius: splashRadius,
                     ),
                     const Expanded(
                       child: TextField(
@@ -34,12 +30,11 @@ class SearchPage extends StatelessWidget {
                     IconButton(
                       icon: const Icon(Icons.mic),
                       onPressed: () {},
-                      splashRadius: splashRadius,
                     )
                   ],
                 ),
               ),
-              const Divider(thickness: 1.1),
+              const Divider(thickness: 1),
               Expanded(
                 child: SingleChildScrollView(
                   child: Column(


### PR DESCRIPTION
This change implements Reply's search page. 
* Implement search page layout
* Transition between home route and search route using shared z axis transition
* Use named routes to navigate
* Introduce `rootNavKey` to be able to call on the root navigator from any screen. 
* Introduce search icon button for desktop/tablet layouts

Desktop|Mobile
---|---
![reply-search-tablet](https://user-images.githubusercontent.com/948037/90328658-078a3880-df53-11ea-8b62-4432bcbc732d.gif)|![shared-z-axis-reply](https://user-images.githubusercontent.com/948037/90325741-393fd700-df34-11ea-8988-2d64b90352da.gif)
