### PR TITLE
[Reply] Make MailView scroll if content no longer fits the screen

### DIFF
--- a/lib/studies/reply/mail_view_page.dart
+++ b/lib/studies/reply/mail_view_page.dart
@@ -18,25 +18,27 @@ class MailViewPage extends StatelessWidget {
     return Scaffold(
       body: SafeArea(
         bottom: false,
-        child: Container(
-          color: Theme.of(context).cardColor,
-          child: Padding(
-            padding: const EdgeInsetsDirectional.only(
-              top: 42,
-              start: 20,
-              end: 20,
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _MailViewHeader(
-                  email: email,
+        child: SizedBox(
+          height: double.infinity,
+          child: Material(
+            color: Theme.of(context).cardColor,
+            child: Padding(
+              padding: const EdgeInsetsDirectional.only(
+                top: 42,
+                start: 20,
+                end: 20,
+              ),
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _MailViewHeader(email: email),
+                    const SizedBox(height: 32),
+                    _MailViewBody(message: email.message),
+                    const SizedBox(height: kToolbarHeight),
+                  ],
                 ),
-                const SizedBox(height: 32),
-                Expanded(
-                  child: _MailViewBody(message: email.message),
-                ),
-              ],
+              ),
             ),
           ),
         ),
@@ -124,11 +126,9 @@ class _MailViewBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      child: Text(
-        message,
-        style: Theme.of(context).textTheme.bodyText2.copyWith(fontSize: 16),
-      ),
+    return Text(
+      message,
+      style: Theme.of(context).textTheme.bodyText2.copyWith(fontSize: 16),
     );
   }
 }

--- a/lib/studies/reply/mail_view_page.dart
+++ b/lib/studies/reply/mail_view_page.dart
@@ -18,26 +18,24 @@ class MailViewPage extends StatelessWidget {
     return Scaffold(
       body: SafeArea(
         bottom: false,
-        child: SizedBox(
+        child: Container(
           height: double.infinity,
           child: Material(
             color: Theme.of(context).cardColor,
-            child: Padding(
+            child: SingleChildScrollView(
               padding: const EdgeInsetsDirectional.only(
                 top: 42,
                 start: 20,
                 end: 20,
               ),
-              child: SingleChildScrollView(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    _MailViewHeader(email: email),
-                    const SizedBox(height: 32),
-                    _MailViewBody(message: email.message),
-                    const SizedBox(height: kToolbarHeight),
-                  ],
-                ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _MailViewHeader(email: email),
+                  const SizedBox(height: 32),
+                  _MailViewBody(message: email.message),
+                  const SizedBox(height: kToolbarHeight),
+                ],
               ),
             ),
           ),


### PR DESCRIPTION
The current behavior of the `MailViewPage` is to allow the body of the message to scroll if the content does not fit. Instead this change wraps the whole page in a `SingleChildScrollView`, so the whole page scrolls when the content does not fit. This is consistent with the behavior in the Android Reply app. 

* This change also fixes ink splash not appearing on material widgets, by wrapping with `Material()` instead of a `Container()`.
* Uses `SingleChildScrollView` `padding` property instead of a 'Padding' widget.