### PR TITLE
[Reply] Fade through transition between different inboxes

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -933,10 +933,10 @@ class _MailNavigator extends StatefulWidget {
   final Widget child;
 
   @override
-  __MailNavigatorState createState() => __MailNavigatorState();
+  _MailNavigatorState createState() => _MailNavigatorState();
 }
 
-class __MailNavigatorState extends State<_MailNavigator> {
+class _MailNavigatorState extends State<_MailNavigator> {
   @override
   Widget build(BuildContext context) {
     return Navigator(

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -467,11 +467,11 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
       vsync: this,
     );
 
-    final destinationKeyList = widget.destinations.keys.toList();
+    final destinationKeysList = widget.destinations.keys.toList();
 
     for (var i = 0; i < widget.destinations.keys.length; i++) {
       if (i == widget.selectedIndex) {
-        _currentDestination = destinationKeyList[i];
+        _currentDestination = destinationKeysList[i];
       }
     }
 
@@ -481,8 +481,10 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
     //destination.
     _destinationsWithIndex = {
       for (var i = 0; i < widget.destinations.keys.length; i++)
-        destinationKeyList[i]: i
+        destinationKeysList[i]: i
     };
+
+    destinationKeysList.clear();
 
     _currentInbox = InboxPage(
       key: UniqueKey(),

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -274,6 +274,7 @@ class _DesktopNavState extends State<_DesktopNav>
           const VerticalDivider(thickness: 1, width: 1),
           Expanded(
             child: _MailNavigator(
+              key: mailNavKey,
               child: _InboxTransitionSwitcher(
                 child: widget.currentInbox,
               ),
@@ -593,6 +594,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
       key: _bottomDrawerKey,
       children: [
         _MailNavigator(
+          key: mailNavKey,
           child: _InboxTransitionSwitcher(
             child: widget.currentInbox,
           ),
@@ -916,7 +918,9 @@ class _BottomDrawerFolderSection extends StatelessWidget {
 }
 
 class _MailNavigator extends StatefulWidget {
-  const _MailNavigator({@required this.child}) : assert(child != null);
+  const _MailNavigator({@required this.child, Key key})
+      : assert(child != null),
+        super(key: key);
 
   final Widget child;
 
@@ -928,7 +932,7 @@ class _MailNavigatorState extends State<_MailNavigator> {
   @override
   Widget build(BuildContext context) {
     return Navigator(
-      key: mailNavKey,
+      key: widget.key,
       onGenerateRoute: (settings) {
         return MaterialPageRoute<void>(builder: (context) {
           return widget.child;

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -113,7 +113,6 @@ class _DesktopNavState extends State<_DesktopNav>
   bool _hasWidgetUpdated = false;
   AnimationController _controller;
   Map<int, String> _indexWithDestinations;
-  int _destinationsCount;
   Widget _currentInbox;
 
   @override
@@ -135,22 +134,20 @@ class _DesktopNavState extends State<_DesktopNav>
           });
         }
       });
-    _destinationsCount = 0;
+
+    final destinationKeysList = widget.destinations.keys.toList();
 
     _indexWithDestinations = {
-      for (var destination in widget.destinations.keys) _nextInt: destination
+      for (var i = 0; i < widget.destinations.keys.length; i++)
+        i: destinationKeysList[i]
     };
+
+    destinationKeysList.clear();
 
     _currentInbox = InboxPage(
       key: UniqueKey(),
       destination: _indexWithDestinations[widget.selectedIndex],
     );
-  }
-
-  int get _nextInt {
-    final _lastInt = _destinationsCount;
-    _destinationsCount = _destinationsCount + 1;
-    return _lastInt;
   }
 
   @override
@@ -442,7 +439,6 @@ class _MobileNav extends StatefulWidget {
 
 class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
   final _bottomDrawerKey = GlobalKey(debugLabel: 'Bottom Drawer');
-  int _destinationsCount;
   AnimationController _drawerController;
   AnimationController _dropArrowController;
   Map<String, int> _destinationsWithIndex;
@@ -470,23 +466,22 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
       duration: const Duration(milliseconds: 350),
       vsync: this,
     );
-    _destinationsCount = 0;
 
-    for (var destination in widget.destinations.keys) {
-      if (_destinationsCount == widget.selectedIndex) {
-        _currentDestination = destination;
+    final destinationKeyList = widget.destinations.keys.toList();
+
+    for (var i = 0; i < widget.destinations.keys.length; i++) {
+      if (i == widget.selectedIndex) {
+        _currentDestination = destinationKeyList[i];
       }
-      _destinationsCount = _destinationsCount + 1;
     }
-
-    _destinationsCount = 0;
 
     //Build a map from destinations with the name of destination as the key and
     //a value from 0 .. # of destinations. Since our destinations are an ordered
     //LinkedHashMap we can use this map to keep track of the indexes for each
     //destination.
     _destinationsWithIndex = {
-      for (var destination in widget.destinations.keys) destination: _nextInt
+      for (var i = 0; i < widget.destinations.keys.length; i++)
+        destinationKeyList[i]: i
     };
 
     _currentInbox = InboxPage(
@@ -511,12 +506,6 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
     _drawerController.dispose();
     _dropArrowController.dispose();
     super.dispose();
-  }
-
-  int get _nextInt {
-    final _lastInt = _destinationsCount;
-    _destinationsCount = _destinationsCount + 1;
-    return _lastInt;
   }
 
   bool get _bottomDrawerVisible {

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -17,7 +17,8 @@ import 'package:provider/provider.dart';
 const _assetsPackage = 'flutter_gallery_assets';
 const _iconAssetLocation = 'reply/icons';
 const _folderIconAssetLocation = '$_iconAssetLocation/twotone_folder.png';
-final mailNavKey = GlobalKey<NavigatorState>();
+final desktopMailNavKey = GlobalKey<NavigatorState>();
+final mobileMailNavKey = GlobalKey<NavigatorState>();
 const double _kFlingVelocity = 2.0;
 
 class AdaptiveNav extends StatefulWidget {
@@ -127,12 +128,17 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
     emailStore.currentlySelectedInbox = destination;
 
     if (emailStore.onMailView) {
-      mailNavKey.currentState.pop();
+      var isDesktop = isDisplayDesktop(context);
+
+      if (isDesktop) {
+        desktopMailNavKey.currentState.pop();
+      } else {
+        mobileMailNavKey.currentState.pop();
+      }
       emailStore.currentlySelectedEmailId = -1;
     }
 
     setState(() {
-      print('hmm');
       _selectedIndex = index;
       _currentInbox = InboxPage(
         key: UniqueKey(),
@@ -274,7 +280,6 @@ class _DesktopNavState extends State<_DesktopNav>
           const VerticalDivider(thickness: 1, width: 1),
           Expanded(
             child: _MailNavigator(
-              key: mailNavKey,
               child: _InboxTransitionSwitcher(
                 child: widget.currentInbox,
               ),
@@ -594,7 +599,6 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
       key: _bottomDrawerKey,
       children: [
         _MailNavigator(
-          key: mailNavKey,
           child: _InboxTransitionSwitcher(
             child: widget.currentInbox,
           ),
@@ -918,9 +922,7 @@ class _BottomDrawerFolderSection extends StatelessWidget {
 }
 
 class _MailNavigator extends StatefulWidget {
-  const _MailNavigator({@required this.child, Key key})
-      : assert(child != null),
-        super(key: key);
+  const _MailNavigator({@required this.child}) : assert(child != null);
 
   final Widget child;
 
@@ -931,8 +933,10 @@ class _MailNavigator extends StatefulWidget {
 class _MailNavigatorState extends State<_MailNavigator> {
   @override
   Widget build(BuildContext context) {
+    final isDesktop = isDisplayDesktop(context);
+
     return Navigator(
-      key: widget.key,
+      key: isDesktop ? desktopMailNavKey : mobileMailNavKey,
       onGenerateRoute: (settings) {
         return MaterialPageRoute<void>(builder: (context) {
           return widget.child;

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -683,7 +683,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
                     const SizedBox(width: 10),
                     Consumer<EmailStore>(
                       builder: (context, model, child) {
-                        final onMailView = model.currentlySelectedEmailId >= 0;
+                        final onMailView = model.onMailView;
 
                         return AnimatedOpacity(
                           opacity:
@@ -730,7 +730,7 @@ class _BottomAppBarActionItems extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<EmailStore>(
       builder: (context, model, child) {
-        final onMailView = model.currentlySelectedEmailId >= 0;
+        final onMailView = model.onMailView;
 
         return AnimatedSwitcher(
           duration: const Duration(milliseconds: 350),
@@ -990,7 +990,7 @@ class _ReplyFabState extends State<_ReplyFab>
       closedBuilder: (context, openContainer) {
         return Consumer<EmailStore>(
           builder: (context, model, child) {
-            final onMailView = model.currentlySelectedEmailId != -1;
+            final onMailView = model.onMailView;
 
             if (isDesktop) {
               return AnimatedSize(
@@ -1055,9 +1055,8 @@ class _FabSwitcher extends StatelessWidget {
               Icons.reply_all,
               key: UniqueKey(),
             )
-          : Icon(
+          : const Icon(
               Icons.create,
-              key: UniqueKey(),
             ),
     );
   }

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -27,6 +27,17 @@ class AdaptiveNav extends StatefulWidget {
 class _AdaptiveNavState extends State<AdaptiveNav> {
   int _selectedIndex = 0;
 
+  Widget _currentInbox;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentInbox = InboxPage(
+      key: UniqueKey(),
+      destination: 'Inbox',
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
@@ -66,11 +77,6 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
       ),
     ];
 
-    final _currentInbox = InboxPage(
-      key: UniqueKey(),
-      destination: _navigationDestinations[_selectedIndex].name,
-    );
-
     final _folders = <String, String>{
       'Receipts': _folderIconAssetLocation,
       'Pine Elementary': _folderIconAssetLocation,
@@ -88,6 +94,7 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
         destinations: _navigationDestinations,
         folders: _folders,
         onItemTapped: _onDestinationSelected,
+        setInbox: _onUpdateInbox,
       );
     } else if (isDesktop) {
       return _DesktopNav(
@@ -97,6 +104,7 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
         destinations: _navigationDestinations,
         folders: _folders,
         onItemTapped: _onDestinationSelected,
+        setInbox: _onUpdateInbox,
       );
     } else {
       return _MobileNav(
@@ -105,6 +113,7 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
         destinations: _navigationDestinations,
         folders: _folders,
         onItemTapped: _onDestinationSelected,
+        setInbox: _onUpdateInbox,
       );
     }
   }
@@ -113,6 +122,13 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
     setState(() {
       _selectedIndex = index;
     });
+  }
+
+  void _onUpdateInbox(String destination) {
+    _currentInbox = InboxPage(
+      key: UniqueKey(),
+      destination: destination,
+    );
   }
 }
 
@@ -125,6 +141,7 @@ class _DesktopNav extends StatefulWidget {
     this.destinations,
     this.folders,
     this.onItemTapped,
+    this.setInbox,
   }) : super(key: key);
 
   final int selectedIndex;
@@ -133,6 +150,7 @@ class _DesktopNav extends StatefulWidget {
   final List<_Destination> destinations;
   final Map<String, String> folders;
   final void Function(int) onItemTapped;
+  final void Function(String) setInbox;
 
   @override
   _DesktopNavState createState() => _DesktopNavState();
@@ -229,7 +247,10 @@ class _DesktopNavState extends State<_DesktopNav>
                           ),
                         ),
                         selectedIndex: widget.selectedIndex,
-                        onDestinationSelected: widget.onItemTapped,
+                        onDestinationSelected: (index) {
+                          widget.onItemTapped(index);
+                          widget.setInbox(widget.destinations[index].name);
+                        },
                       ),
                     ),
                   ),
@@ -434,19 +455,20 @@ class _NavigationRailFolderSection extends StatelessWidget {
 }
 
 class _MobileNav extends StatefulWidget {
-  const _MobileNav({
-    this.selectedIndex,
-    this.currentInbox,
-    this.destinations,
-    this.folders,
-    this.onItemTapped,
-  });
+  const _MobileNav(
+      {this.selectedIndex,
+      this.currentInbox,
+      this.destinations,
+      this.folders,
+      this.onItemTapped,
+      this.setInbox});
 
   final int selectedIndex;
   final Widget currentInbox;
   final List<_Destination> destinations;
   final Map<String, String> folders;
   final void Function(int) onItemTapped;
+  final void Function(String) setInbox;
 
   @override
   _MobileNavState createState() => _MobileNavState();
@@ -597,6 +619,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
                 dropArrowController: _dropArrowController,
                 selectedIndex: widget.selectedIndex,
                 onItemTapped: widget.onItemTapped,
+                setInbox: widget.setInbox,
               ),
               trailing: _BottomDrawerFolderSection(folders: widget.folders),
             ),
@@ -769,17 +792,20 @@ class _BottomDrawerDestinations extends StatelessWidget {
     @required this.dropArrowController,
     @required this.selectedIndex,
     @required this.onItemTapped,
+    @required this.setInbox,
   })  : assert(destinations != null),
         assert(drawerController != null),
         assert(dropArrowController != null),
         assert(selectedIndex != null),
-        assert(onItemTapped != null);
+        assert(onItemTapped != null),
+        assert(setInbox != null);
 
   final List<_Destination> destinations;
   final AnimationController drawerController;
   final AnimationController dropArrowController;
   final int selectedIndex;
   final void Function(int) onItemTapped;
+  final void Function(String) setInbox;
 
   @override
   Widget build(BuildContext context) {
@@ -805,6 +831,7 @@ class _BottomDrawerDestinations extends StatelessWidget {
                   onItemTapped(
                     destination.index,
                   );
+                  setInbox(destination.name);
                 },
               );
             },

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -66,6 +66,11 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
       ),
     ];
 
+    final _currentInbox = InboxPage(
+      key: UniqueKey(),
+      destination: _navigationDestinations[_selectedIndex].name,
+    );
+
     final _folders = <String, String>{
       'Receipts': _folderIconAssetLocation,
       'Pine Elementary': _folderIconAssetLocation,
@@ -78,6 +83,7 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
     if (isTablet) {
       return _DesktopNav(
         selectedIndex: _selectedIndex,
+        currentInbox: _currentInbox,
         extended: false,
         destinations: _navigationDestinations,
         folders: _folders,
@@ -86,6 +92,7 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
     } else if (isDesktop) {
       return _DesktopNav(
         selectedIndex: _selectedIndex,
+        currentInbox: _currentInbox,
         extended: true,
         destinations: _navigationDestinations,
         folders: _folders,
@@ -94,6 +101,7 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
     } else {
       return _MobileNav(
         selectedIndex: _selectedIndex,
+        currentInbox: _currentInbox,
         destinations: _navigationDestinations,
         folders: _folders,
         onItemTapped: _onDestinationSelected,
@@ -112,6 +120,7 @@ class _DesktopNav extends StatefulWidget {
   const _DesktopNav({
     Key key,
     this.selectedIndex,
+    this.currentInbox,
     this.extended,
     this.destinations,
     this.folders,
@@ -120,7 +129,7 @@ class _DesktopNav extends StatefulWidget {
 
   final int selectedIndex;
   final bool extended;
-
+  final Widget currentInbox;
   final List<_Destination> destinations;
   final Map<String, String> folders;
   final void Function(int) onItemTapped;
@@ -134,7 +143,6 @@ class _DesktopNavState extends State<_DesktopNav>
   bool _isExtended;
   bool _hasWidgetUpdated = false;
   AnimationController _controller;
-  Widget _currentInbox;
 
   @override
   void initState() {
@@ -155,11 +163,6 @@ class _DesktopNavState extends State<_DesktopNav>
           });
         }
       });
-
-    _currentInbox = InboxPage(
-      key: UniqueKey(),
-      destination: widget.destinations[widget.selectedIndex].name,
-    );
   }
 
   @override
@@ -168,13 +171,6 @@ class _DesktopNavState extends State<_DesktopNav>
     if (oldWidget.extended != widget.extended) {
       onLogoTapped();
       _hasWidgetUpdated = true;
-    }
-
-    if (oldWidget.selectedIndex != widget.selectedIndex) {
-      _currentInbox = InboxPage(
-        key: UniqueKey(),
-        destination: widget.destinations[widget.selectedIndex].name,
-      );
     }
   }
 
@@ -245,7 +241,7 @@ class _DesktopNavState extends State<_DesktopNav>
           Expanded(
             child: _MailNavigator(
               child: _InboxTransitionSwitcher(
-                child: _currentInbox,
+                child: widget.currentInbox,
               ),
             ),
           ),
@@ -440,12 +436,14 @@ class _NavigationRailFolderSection extends StatelessWidget {
 class _MobileNav extends StatefulWidget {
   const _MobileNav({
     this.selectedIndex,
+    this.currentInbox,
     this.destinations,
     this.folders,
     this.onItemTapped,
   });
 
   final int selectedIndex;
+  final Widget currentInbox;
   final List<_Destination> destinations;
   final Map<String, String> folders;
   final void Function(int) onItemTapped;
@@ -458,7 +456,6 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
   final _bottomDrawerKey = GlobalKey(debugLabel: 'Bottom Drawer');
   AnimationController _drawerController;
   AnimationController _dropArrowController;
-  Widget _currentInbox;
 
   @override
   void initState() {
@@ -481,22 +478,6 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
       duration: const Duration(milliseconds: 350),
       vsync: this,
     );
-
-    _currentInbox = InboxPage(
-      key: UniqueKey(),
-      destination: widget.destinations[widget.selectedIndex].name,
-    );
-  }
-
-  @override
-  void didUpdateWidget(_MobileNav oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.selectedIndex != widget.selectedIndex) {
-      _currentInbox = InboxPage(
-        key: UniqueKey(),
-        destination: widget.destinations[widget.selectedIndex].name,
-      );
-    }
   }
 
   @override
@@ -579,7 +560,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
       children: [
         _MailNavigator(
           child: _InboxTransitionSwitcher(
-            child: _currentInbox,
+            child: widget.currentInbox,
           ),
         ),
         GestureDetector(
@@ -859,6 +840,7 @@ class _Destination {
     @required this.icon,
     @required this.index,
   })  : assert(name != null),
+        assert(icon != null),
         assert(index != null);
 
   final String name;

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -128,7 +128,7 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
     emailStore.currentlySelectedInbox = destination;
 
     if (emailStore.onMailView) {
-      var isDesktop = isDisplayDesktop(context);
+      final isDesktop = isDisplayDesktop(context);
 
       if (isDesktop) {
         desktopMailNavKey.currentState.pop();

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -118,6 +118,11 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
   }
 
   void _onDestinationSelected(int index, String destination) {
+    Provider.of<EmailStore>(
+      context,
+      listen: false,
+    ).currentlySelectedInbox = destination;
+
     setState(() {
       _selectedIndex = index;
       _currentInbox = InboxPage(

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -17,6 +17,7 @@ import 'package:provider/provider.dart';
 const _assetsPackage = 'flutter_gallery_assets';
 const _iconAssetLocation = 'reply/icons';
 const _folderIconAssetLocation = '$_iconAssetLocation/twotone_folder.png';
+final mailNavKey = GlobalKey<NavigatorState>();
 const double _kFlingVelocity = 2.0;
 
 class AdaptiveNav extends StatefulWidget {
@@ -118,12 +119,20 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
   }
 
   void _onDestinationSelected(int index, String destination) {
-    Provider.of<EmailStore>(
+    var emailStore = Provider.of<EmailStore>(
       context,
       listen: false,
-    ).currentlySelectedInbox = destination;
+    );
+
+    emailStore.currentlySelectedInbox = destination;
+
+    if (emailStore.onMailView) {
+      mailNavKey.currentState.pop();
+      emailStore.currentlySelectedEmailId = -1;
+    }
 
     setState(() {
+      print('hmm');
       _selectedIndex = index;
       _currentInbox = InboxPage(
         key: UniqueKey(),
@@ -919,6 +928,7 @@ class _MailNavigatorState extends State<_MailNavigator> {
   @override
   Widget build(BuildContext context) {
     return Navigator(
+      key: mailNavKey,
       onGenerateRoute: (settings) {
         return MaterialPageRoute<void>(builder: (context) {
           return widget.child;

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -94,7 +94,6 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
         destinations: _navigationDestinations,
         folders: _folders,
         onItemTapped: _onDestinationSelected,
-        setInbox: _onUpdateInbox,
       );
     } else if (isDesktop) {
       return _DesktopNav(
@@ -104,7 +103,6 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
         destinations: _navigationDestinations,
         folders: _folders,
         onItemTapped: _onDestinationSelected,
-        setInbox: _onUpdateInbox,
       );
     } else {
       return _MobileNav(
@@ -113,22 +111,18 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
         destinations: _navigationDestinations,
         folders: _folders,
         onItemTapped: _onDestinationSelected,
-        setInbox: _onUpdateInbox,
       );
     }
   }
 
-  void _onDestinationSelected(int index) {
+  void _onDestinationSelected(int index, String destination) {
     setState(() {
       _selectedIndex = index;
+      _currentInbox = InboxPage(
+        key: UniqueKey(),
+        destination: destination,
+      );
     });
-  }
-
-  void _onUpdateInbox(String destination) {
-    _currentInbox = InboxPage(
-      key: UniqueKey(),
-      destination: destination,
-    );
   }
 }
 
@@ -141,7 +135,6 @@ class _DesktopNav extends StatefulWidget {
     this.destinations,
     this.folders,
     this.onItemTapped,
-    this.setInbox,
   }) : super(key: key);
 
   final int selectedIndex;
@@ -149,8 +142,7 @@ class _DesktopNav extends StatefulWidget {
   final Widget currentInbox;
   final List<_Destination> destinations;
   final Map<String, String> folders;
-  final void Function(int) onItemTapped;
-  final void Function(String) setInbox;
+  final void Function(int, String) onItemTapped;
 
   @override
   _DesktopNavState createState() => _DesktopNavState();
@@ -248,8 +240,10 @@ class _DesktopNavState extends State<_DesktopNav>
                         ),
                         selectedIndex: widget.selectedIndex,
                         onDestinationSelected: (index) {
-                          widget.onItemTapped(index);
-                          widget.setInbox(widget.destinations[index].name);
+                          widget.onItemTapped(
+                            index,
+                            widget.destinations[index].name,
+                          );
                         },
                       ),
                     ),
@@ -455,20 +449,19 @@ class _NavigationRailFolderSection extends StatelessWidget {
 }
 
 class _MobileNav extends StatefulWidget {
-  const _MobileNav(
-      {this.selectedIndex,
-      this.currentInbox,
-      this.destinations,
-      this.folders,
-      this.onItemTapped,
-      this.setInbox});
+  const _MobileNav({
+    this.selectedIndex,
+    this.currentInbox,
+    this.destinations,
+    this.folders,
+    this.onItemTapped,
+  });
 
   final int selectedIndex;
   final Widget currentInbox;
   final List<_Destination> destinations;
   final Map<String, String> folders;
-  final void Function(int) onItemTapped;
-  final void Function(String) setInbox;
+  final void Function(int, String) onItemTapped;
 
   @override
   _MobileNavState createState() => _MobileNavState();
@@ -619,7 +612,6 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
                 dropArrowController: _dropArrowController,
                 selectedIndex: widget.selectedIndex,
                 onItemTapped: widget.onItemTapped,
-                setInbox: widget.setInbox,
               ),
               trailing: _BottomDrawerFolderSection(folders: widget.folders),
             ),
@@ -792,20 +784,17 @@ class _BottomDrawerDestinations extends StatelessWidget {
     @required this.dropArrowController,
     @required this.selectedIndex,
     @required this.onItemTapped,
-    @required this.setInbox,
   })  : assert(destinations != null),
         assert(drawerController != null),
         assert(dropArrowController != null),
         assert(selectedIndex != null),
-        assert(onItemTapped != null),
-        assert(setInbox != null);
+        assert(onItemTapped != null);
 
   final List<_Destination> destinations;
   final AnimationController drawerController;
   final AnimationController dropArrowController;
   final int selectedIndex;
-  final void Function(int) onItemTapped;
-  final void Function(String) setInbox;
+  final void Function(int, String) onItemTapped;
 
   @override
   Widget build(BuildContext context) {
@@ -828,10 +817,7 @@ class _BottomDrawerDestinations extends StatelessWidget {
                   // Wait until animations are complete to reload the state.
                   // Delay is variable based on if the gallery is in slow motion
                   // mode or not.
-                  onItemTapped(
-                    destination.index,
-                  );
-                  setInbox(destination.name);
+                  onItemTapped(destination.index, destination.name);
                 },
               );
             },

--- a/lib/studies/reply/compose_page.dart
+++ b/lib/studies/reply/compose_page.dart
@@ -15,8 +15,8 @@ class ComposePage extends StatelessWidget {
     final emailStore = Provider.of<EmailStore>(context);
 
     if (emailStore.currentlySelectedEmailId >= 0) {
-      final currentEmail =
-          emailStore.emails[emailStore.currentlySelectedEmailId];
+      final currentEmail = emailStore.emails[emailStore.currentlySelectedInbox]
+          [emailStore.currentlySelectedEmailId];
       _subject = currentEmail.subject;
       _recipient = currentEmail.sender;
       _recipientAvatar = currentEmail.avatar;

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -5,7 +5,11 @@ import 'package:gallery/studies/reply/model/email_store.dart';
 import 'package:provider/provider.dart';
 
 class InboxPage extends StatelessWidget {
-  const InboxPage({Key key}) : super(key: key);
+  const InboxPage({Key key, @required this.destination})
+      : assert(destination != null),
+        super(key: key);
+
+  final String destination;
 
   @override
   Widget build(BuildContext context) {
@@ -29,11 +33,11 @@ class InboxPage extends StatelessWidget {
                   ),
                   children: [
                     for (int index = 0;
-                        index < model.emails.length;
+                        index < model.emails[destination].length;
                         index++) ...[
                       MailPreviewCard(
                         id: index,
-                        email: model.emails[index],
+                        email: model.emails[destination][index],
                       ),
                       const SizedBox(height: 4),
                     ],

--- a/lib/studies/reply/model/email_store.dart
+++ b/lib/studies/reply/model/email_store.dart
@@ -188,6 +188,7 @@ class EmailStore with ChangeNotifier {
   ];
 
   int _currentlySelectedEmailId = -1;
+  String _currentlySelectedInbox = 'Inbox';
 
   Map<String, List<Email>> get emails =>
       Map<String, List<Email>>.unmodifiable(_categories);
@@ -198,9 +199,15 @@ class EmailStore with ChangeNotifier {
   }
 
   int get currentlySelectedEmailId => _currentlySelectedEmailId;
+  String get currentlySelectedInbox => _currentlySelectedInbox;
 
   set currentlySelectedEmailId(int value) {
     _currentlySelectedEmailId = value;
+    notifyListeners();
+  }
+
+  set currentlySelectedInbox(String inbox) {
+    _currentlySelectedInbox = inbox;
     notifyListeners();
   }
 }

--- a/lib/studies/reply/model/email_store.dart
+++ b/lib/studies/reply/model/email_store.dart
@@ -5,7 +5,16 @@ import 'email_model.dart';
 const _avatarsLocation = 'reply/avatars';
 
 class EmailStore with ChangeNotifier {
-  final List<Email> _emails = const [
+  final Map<String, List<Email>> _categories = {
+    'Inbox': _mainInbox,
+    'Starred': _starredInbox,
+    'Sent': _outbox,
+    'Trash': _trash,
+    'Spam': _spam,
+    'Drafts': _drafts,
+  };
+
+  static final List<Email> _mainInbox = const [
     Email(
       sender: 'Google Express',
       time: '15 minutes ago',
@@ -85,6 +94,11 @@ class EmailStore with ChangeNotifier {
       containsPictures: false,
       isRead: false,
     ),
+  ];
+
+  static final List<Email> _starredInbox = [];
+
+  static final List<Email> _outbox = const [
     Email(
       sender: 'Kim Alen',
       time: '4 hrs ago',
@@ -112,6 +126,9 @@ class EmailStore with ChangeNotifier {
       containsPictures: false,
       isRead: false,
     ),
+  ];
+
+  static final List<Email> _trash = const [
     Email(
       sender: 'Frank Hawkins',
       time: '4 hrs ago',
@@ -138,6 +155,9 @@ class EmailStore with ChangeNotifier {
       containsPictures: false,
       isRead: false,
     ),
+  ];
+
+  static final List<Email> _spam = const [
     Email(
       sender: 'Allison Trabucco',
       time: '4 hrs ago',
@@ -150,6 +170,9 @@ class EmailStore with ChangeNotifier {
       containsPictures: false,
       isRead: false,
     ),
+  ];
+
+  static final List<Email> _drafts = const [
     Email(
       sender: 'Sandra Adams',
       time: '2 hrs ago',
@@ -166,10 +189,11 @@ class EmailStore with ChangeNotifier {
 
   int _currentlySelectedEmailId = -1;
 
-  List<Email> get emails => List<Email>.unmodifiable(_emails);
+  Map<String, List<Email>> get emails =>
+      Map<String, List<Email>>.unmodifiable(_categories);
 
-  void deleteEmail(int id) {
-    _emails.removeAt(id);
+  void deleteEmail(String category, int id) {
+    _categories[category].removeAt(id);
     notifyListeners();
   }
 

--- a/lib/studies/reply/model/email_store.dart
+++ b/lib/studies/reply/model/email_store.dart
@@ -200,6 +200,7 @@ class EmailStore with ChangeNotifier {
 
   int get currentlySelectedEmailId => _currentlySelectedEmailId;
   String get currentlySelectedInbox => _currentlySelectedInbox;
+  bool get onMailView => _currentlySelectedEmailId > -1;
 
   set currentlySelectedEmailId(int value) {
     _currentlySelectedEmailId = value;


### PR DESCRIPTION
* Add `_InboxTransitionSwitcher()` to transition between different destinations in the nav rail/drawer or bottom drawer
* Split `_emails` in `EmailStore` into different inboxes, and link them using a `Map<String, List<Email>>`
* Make `_MailNavigator` a stateful widget to support rebuilding the inbox which allows for `FadeThroughTransition` to fade between different inboxes
* Implement `_Destination` to hold the icon, name, and index of a destination. This solution replaces the previous implementation of destinations as a `Map<String, String>`, with `List<_Destination>`, and allows us to remove a lot of overhead that was introduced by using `Map`.
* Make `DesktopNav` and `MobileNav` inherit `currentInbox` from `AdaptiveNav`


Desktop|Mobile
---|---
![reply-fade-through-desktop](https://user-images.githubusercontent.com/948037/90344777-d69d1880-dfd1-11ea-8d6d-6a8e2f547d2e.gif)|![reply-fade-through-mobile](https://user-images.githubusercontent.com/948037/90344783-e74d8e80-dfd1-11ea-9e0f-cdd8ea6f818c.gif)
