### PR TITLE
[Reply] Dismissible email for mobile

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -287,13 +287,10 @@ class _NavigationRailHeader extends StatelessWidget {
                   child: Row(
                     children: const [
                       SizedBox(width: 36),
-                      Align(
-                        alignment: Alignment(0, -1.5),
-                        child: ProfileAvatar(
-                          avatar: 'reply/avatars/avatar_2.jpg',
-                          height: 32,
-                          width: 32,
-                        ),
+                      ProfileAvatar(
+                        avatar: 'reply/avatars/avatar_2.jpg',
+                        height: 32,
+                        width: 32,
                       ),
                       SizedBox(width: 12),
                       Icon(

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -289,8 +289,7 @@ class _NavigationRailHeader extends StatelessWidget {
                       SizedBox(width: 36),
                       ProfileAvatar(
                         avatar: 'reply/avatars/avatar_2.jpg',
-                        height: 32,
-                        width: 32,
+                        radius: 16,
                       ),
                       SizedBox(width: 12),
                       Icon(

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -22,7 +22,7 @@ class ReplyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     final galleryThemeMode = GalleryOptions.of(context).themeMode;
     final isDark = galleryThemeMode == ThemeMode.system
-        ? MediaQuery.of(context).platformBrightness == Brightness.dark
+        ? Theme.of(context).brightness == Brightness.dark
         : galleryThemeMode == ThemeMode.dark;
 
     final replyTheme =

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -40,6 +40,8 @@ class InboxPage extends StatelessWidget {
                       MailPreviewCard(
                         id: index,
                         email: model.emails[destination][index],
+                        onDelete: () => model.deleteEmail(destination, index),
+                        onStar: () => model.starEmail(destination, index),
                       ),
                       const SizedBox(height: 4),
                     ],

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -16,12 +16,16 @@ class MailPreviewCard extends StatelessWidget {
     Key key,
     @required this.id,
     @required this.email,
+    @required this.onDelete,
+    @required this.onStar,
   })  : assert(id != null),
         assert(email != null),
         super(key: key);
 
   final int id;
   final Email email;
+  final VoidCallback onDelete;
+  final VoidCallback onStar;
 
   @override
   Widget build(BuildContext context) {
@@ -49,6 +53,11 @@ class MailPreviewCard extends StatelessWidget {
           message: email.message,
           onTap: openContainer,
         );
+        final onStarredInbox = Provider.of<EmailStore>(
+              context,
+              listen: false,
+            ).currentlySelectedInbox ==
+            'Starred';
 
         if (isDesktop) {
           return mailPreview;
@@ -62,8 +71,12 @@ class MailPreviewCard extends StatelessWidget {
             onDismissed: (direction) {
               switch (direction) {
                 case DismissDirection.endToStart:
+                  if (onStarredInbox) {
+                    onDelete();
+                  }
                   break;
                 case DismissDirection.startToEnd:
+                  onDelete();
                   break;
                 default:
               }
@@ -75,6 +88,17 @@ class MailPreviewCard extends StatelessWidget {
               alignment: Alignment.centerLeft,
               padding: const EdgeInsetsDirectional.only(start: 20),
             ),
+            confirmDismiss: (direction) async {
+              if (direction == DismissDirection.endToStart) {
+                if (onStarredInbox) {
+                  return true;
+                }
+                onStar();
+                return false;
+              } else {
+                return true;
+              }
+            },
             secondaryBackground: _DismissibleContainer(
               icon: 'twotone_star',
               backgroundColor: colorScheme.secondary,

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -65,8 +65,8 @@ class MailPreviewCard extends StatelessWidget {
           return Dismissible(
             key: ObjectKey(email),
             dismissThresholds: const {
-              DismissDirection.startToEnd: 0.4,
-              DismissDirection.endToStart: 1,
+              DismissDirection.startToEnd: 0.8,
+              DismissDirection.endToStart: 0.4,
             },
             onDismissed: (direction) {
               switch (direction) {

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -33,9 +33,7 @@ class MailPreviewCard extends StatelessWidget {
       },
       openColor: theme.cardColor,
       closedShape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(
-          Radius.circular(0),
-        ),
+        borderRadius: BorderRadius.all(Radius.circular(0)),
       ),
       closedElevation: 0,
       closedColor: theme.cardColor,
@@ -174,7 +172,7 @@ class _MailPreview extends StatelessWidget {
           return ConstrainedBox(
             constraints: BoxConstraints(maxHeight: constraints.maxHeight),
             child: Padding(
-              padding: const EdgeInsets.all(20.0),
+              padding: const EdgeInsets.all(20),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -259,11 +257,7 @@ class _MailPreviewActionBar extends StatelessWidget {
           ),
           const SizedBox(width: 16),
         ],
-        ProfileAvatar(
-          avatar: avatar,
-          height: 36,
-          width: 36,
-        ),
+        ProfileAvatar(avatar: avatar),
       ],
     );
   }

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -72,7 +72,7 @@ class MailPreviewCard extends StatelessWidget {
               switch (direction) {
                 case DismissDirection.endToStart:
                   if (onStarredInbox) {
-                    onDelete();
+                    onStar();
                   }
                   break;
                 case DismissDirection.startToEnd:

--- a/lib/studies/reply/mail_view_page.dart
+++ b/lib/studies/reply/mail_view_page.dart
@@ -102,8 +102,8 @@ class _MailViewHeader extends StatelessWidget {
                 ),
               ],
             ),
-            Transform.translate(
-              offset: const Offset(-8, 0),
+            Padding(
+              padding: const EdgeInsetsDirectional.only(end: 4),
               child: ProfileAvatar(avatar: email.avatar),
             ),
           ],

--- a/lib/studies/reply/mail_view_page.dart
+++ b/lib/studies/reply/mail_view_page.dart
@@ -104,11 +104,7 @@ class _MailViewHeader extends StatelessWidget {
             ),
             Transform.translate(
               offset: const Offset(-8, 0),
-              child: ProfileAvatar(
-                avatar: email.avatar,
-                height: 36,
-                width: 36,
-              ),
+              child: ProfileAvatar(avatar: email.avatar),
             ),
           ],
         ),

--- a/lib/studies/reply/model/email_store.dart
+++ b/lib/studies/reply/model/email_store.dart
@@ -194,7 +194,15 @@ class EmailStore with ChangeNotifier {
       Map<String, List<Email>>.unmodifiable(_categories);
 
   void deleteEmail(String category, int id) {
+    final email = _categories[category].elementAt(id);
+
     _categories[category].removeAt(id);
+
+    _categories.forEach((key, value) {
+      if (value.contains(email)) {
+        value.remove(email);
+      }
+    });
 
     notifyListeners();
   }

--- a/lib/studies/reply/model/email_store.dart
+++ b/lib/studies/reply/model/email_store.dart
@@ -5,7 +5,7 @@ import 'email_model.dart';
 const _avatarsLocation = 'reply/avatars';
 
 class EmailStore with ChangeNotifier {
-  final Map<String, List<Email>> _categories = {
+  final _categories = <String, List<Email>>{
     'Inbox': _mainInbox,
     'Starred': _starredInbox,
     'Sent': _outbox,
@@ -14,8 +14,8 @@ class EmailStore with ChangeNotifier {
     'Drafts': _drafts,
   };
 
-  static final List<Email> _mainInbox = const [
-    Email(
+  static final _mainInbox = <Email>[
+    const Email(
       sender: 'Google Express',
       time: '15 minutes ago',
       subject: 'Package shipped!',
@@ -28,7 +28,7 @@ class EmailStore with ChangeNotifier {
       containsPictures: false,
       isRead: false,
     ),
-    Email(
+    const Email(
       sender: 'Ali Connors',
       time: '4 hrs ago',
       subject: 'Brunch this weekend?',
@@ -43,7 +43,7 @@ class EmailStore with ChangeNotifier {
       containsPictures: false,
       isRead: false,
     ),
-    Email(
+    const Email(
       sender: 'Allison Trabucco',
       time: '5 hrs ago',
       subject: 'Bonjour from Paris',
@@ -54,7 +54,7 @@ class EmailStore with ChangeNotifier {
       containsPictures: true,
       isRead: false,
     ),
-    Email(
+    const Email(
       sender: 'Trevor Hansen',
       time: '9 hrs ago',
       subject: 'Brazil trip',
@@ -72,7 +72,7 @@ class EmailStore with ChangeNotifier {
       containsPictures: false,
       isRead: false,
     ),
-    Email(
+    const Email(
       sender: 'Frank Hawkins',
       time: '10 hrs ago',
       subject: 'Update to Your Itinerary',
@@ -83,7 +83,7 @@ class EmailStore with ChangeNotifier {
       containsPictures: false,
       isRead: false,
     ),
-    Email(
+    const Email(
       sender: 'Google Express',
       time: '12 hrs ago',
       subject: 'Delivered',
@@ -96,10 +96,10 @@ class EmailStore with ChangeNotifier {
     ),
   ];
 
-  static final List<Email> _starredInbox = [];
+  static final _starredInbox = <Email>[];
 
-  static final List<Email> _outbox = const [
-    Email(
+  static final _outbox = <Email>[
+    const Email(
       sender: 'Kim Alen',
       time: '4 hrs ago',
       subject: 'High school reunion?',
@@ -113,7 +113,7 @@ class EmailStore with ChangeNotifier {
       containsPictures: false,
       isRead: false,
     ),
-    Email(
+    const Email(
       sender: 'Sandra Adams',
       time: '7 hrs ago',
       subject: 'Recipe to try',
@@ -128,8 +128,8 @@ class EmailStore with ChangeNotifier {
     ),
   ];
 
-  static final List<Email> _trash = const [
-    Email(
+  static final _trash = <Email>[
+    const Email(
       sender: 'Frank Hawkins',
       time: '4 hrs ago',
       subject: 'Your update on the Google Play Store is live!',
@@ -142,7 +142,7 @@ class EmailStore with ChangeNotifier {
       containsPictures: false,
       isRead: false,
     ),
-    Email(
+    const Email(
       sender: 'Allison Trabucco',
       time: '6 hrs ago',
       subject: 'Try a free TrailGo account',
@@ -157,8 +157,8 @@ class EmailStore with ChangeNotifier {
     ),
   ];
 
-  static final List<Email> _spam = const [
-    Email(
+  static final _spam = <Email>[
+    const Email(
       sender: 'Allison Trabucco',
       time: '4 hrs ago',
       subject: 'Free money',
@@ -172,8 +172,8 @@ class EmailStore with ChangeNotifier {
     ),
   ];
 
-  static final List<Email> _drafts = const [
-    Email(
+  static final _drafts = <Email>[
+    const Email(
       sender: 'Sandra Adams',
       time: '2 hrs ago',
       subject: '(No subject)',
@@ -195,6 +195,20 @@ class EmailStore with ChangeNotifier {
 
   void deleteEmail(String category, int id) {
     _categories[category].removeAt(id);
+
+    notifyListeners();
+  }
+
+  void starEmail(String category, int id) {
+    final email = _categories[category].elementAt(id);
+    var alreadyStarred = _categories['Starred'].contains(email);
+
+    if (alreadyStarred) {
+      _categories['Starred'].remove(email);
+    } else {
+      _categories['Starred'].add(email);
+    }
+
     notifyListeners();
   }
 

--- a/lib/studies/reply/profile_avatar.dart
+++ b/lib/studies/reply/profile_avatar.dart
@@ -15,12 +15,15 @@ class ProfileAvatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ClipOval(
+    return Material(
+      color: Colors.transparent,
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
       child: Image.asset(
         avatar,
         package: 'flutter_gallery_assets',
-        height: height,
         width: width,
+        height: height,
       ),
     );
   }

--- a/lib/studies/reply/profile_avatar.dart
+++ b/lib/studies/reply/profile_avatar.dart
@@ -3,27 +3,23 @@ import 'package:flutter/material.dart';
 class ProfileAvatar extends StatelessWidget {
   const ProfileAvatar({
     @required this.avatar,
-    @required this.height,
-    @required this.width,
-  })  : assert(avatar != null),
-        assert(height != null),
-        assert(width != null);
+    this.radius,
+  }) : assert(avatar != null);
 
   final String avatar;
-  final double height;
-  final double width;
+  final double radius;
 
   @override
   Widget build(BuildContext context) {
     return Material(
       color: Colors.transparent,
-      shape: const CircleBorder(),
-      clipBehavior: Clip.antiAlias,
-      child: Image.asset(
-        avatar,
-        package: 'flutter_gallery_assets',
-        width: width,
-        height: height,
+      child: CircleAvatar(
+        radius: radius,
+        backgroundImage: AssetImage(
+          avatar,
+          package: 'flutter_gallery_assets',
+        ),
+        backgroundColor: Theme.of(context).cardColor,
       ),
     );
   }


### PR DESCRIPTION
* Implements swipe to dismiss email on swipe from start to end
* Implements swipe to star email on swipe from end to start, once it crosses the 0.4 threshold the tile jumps and returns to its original position
* Swipe from end to start on a unstarred email will star it
* Swipe from end to start on a starred email will unstar it
* Swipe from end to start on a starred email on the starred inbox will dismiss it from the starred inbox
* Dismiss on swipe from end to start disabled unless on starred inbox
* Swipe from start to end to dismiss email from list
* Revamp `EmailStore` to support starring and dismissing emails
* Revamp `ProfileAvatar` to use `CircleAvatar`, allows us to get rid of `Transform.translate` and other alignment solutions that were used for `ProfileAvatar` placement
* Implements `DismissibleContainer` that holds the widgets that make up the background for a `Dismissible`


![reply-dismissable-functionality](https://user-images.githubusercontent.com/948037/90716101-f39b4b00-e260-11ea-871c-bf2ed7824abd.gif)
