### PR TITLE
[Reply] Implement picture support for emails

### DIFF
--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -249,7 +249,6 @@ class _PicturePreview extends StatelessWidget {
               child: Image.asset(
                 'reply/attachments/paris_${index + 1}.jpg',
                 package: 'flutter_gallery_assets',
-                isAntiAlias: true,
               ),
             ),
         ],

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -46,11 +46,7 @@ class MailPreviewCard extends StatelessWidget {
         final colorScheme = theme.colorScheme;
         final mailPreview = _MailPreview(
           id: id,
-          sender: email.sender,
-          time: email.time,
-          subject: email.subject,
-          avatar: email.avatar,
-          message: email.message,
+          email: email,
           onTap: openContainer,
         );
         final onStarredInbox = Provider.of<EmailStore>(
@@ -157,26 +153,14 @@ class _DismissibleContainer extends StatelessWidget {
 class _MailPreview extends StatelessWidget {
   const _MailPreview({
     @required this.id,
-    @required this.sender,
-    @required this.time,
-    @required this.subject,
-    @required this.avatar,
-    @required this.message,
+    @required this.email,
     @required this.onTap,
   })  : assert(id != null),
-        assert(sender != null),
-        assert(time != null),
-        assert(subject != null),
-        assert(avatar != null),
-        assert(message != null),
+        assert(email != null),
         assert(onTap != null);
 
   final int id;
-  final String sender;
-  final String time;
-  final String subject;
-  final String avatar;
-  final String message;
+  final Email email;
   final VoidCallback onTap;
 
   @override
@@ -210,17 +194,17 @@ class _MailPreview extends StatelessWidget {
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: [
                             Text(
-                              '$sender - $time',
+                              '${email.sender} - ${email.time}',
                               style: textTheme.caption,
                             ),
                             const SizedBox(height: 4),
-                            Text(subject, style: textTheme.headline6),
+                            Text(email.subject, style: textTheme.headline6),
                             const SizedBox(height: 16),
                           ],
                         ),
                       ),
                       _MailPreviewActionBar(
-                        avatar: avatar,
+                        avatar: email.avatar,
                       ),
                     ],
                   ),
@@ -229,17 +213,46 @@ class _MailPreview extends StatelessWidget {
                       end: 20,
                     ),
                     child: Text(
-                      message,
+                      email.message,
                       overflow: TextOverflow.ellipsis,
                       maxLines: 1,
                       style: textTheme.bodyText2,
                     ),
                   ),
+                  if (email.containsPictures) ...[
+                    const SizedBox(height: 20),
+                    const _PicturePreview(),
+                  ],
                 ],
               ),
             ),
           );
         },
+      ),
+    );
+  }
+}
+
+class _PicturePreview extends StatelessWidget {
+  const _PicturePreview();
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 96,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        children: [
+          for (var index = 0; index < 4; index++)
+            Padding(
+              padding: const EdgeInsetsDirectional.only(end: 4),
+              child: Image.asset(
+                'reply/attachments/paris_${index + 1}.jpg',
+                package: 'flutter_gallery_assets',
+                isAntiAlias: true,
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/studies/reply/mail_view_page.dart
+++ b/lib/studies/reply/mail_view_page.dart
@@ -30,10 +30,15 @@ class MailViewPage extends StatelessWidget {
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
                 children: [
                   _MailViewHeader(email: email),
                   const SizedBox(height: 32),
                   _MailViewBody(message: email.message),
+                  if (email.containsPictures) ...[
+                    const SizedBox(height: 28),
+                    const _PictureGrid(),
+                  ],
                   const SizedBox(height: kToolbarHeight),
                 ],
               ),
@@ -123,6 +128,31 @@ class _MailViewBody extends StatelessWidget {
     return Text(
       message,
       style: Theme.of(context).textTheme.bodyText2.copyWith(fontSize: 16),
+    );
+  }
+}
+
+class _PictureGrid extends StatelessWidget {
+  const _PictureGrid();
+
+  @override
+  Widget build(BuildContext context) {
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        crossAxisSpacing: 4,
+        mainAxisSpacing: 4,
+      ),
+      itemCount: 4,
+      itemBuilder: (context, index) {
+        return Image.asset(
+          'reply/attachments/paris_${index + 1}.jpg',
+          package: 'flutter_gallery_assets',
+          fit: BoxFit.fill,
+        );
+      },
     );
   }
 }

--- a/lib/studies/reply/mail_view_page.dart
+++ b/lib/studies/reply/mail_view_page.dart
@@ -30,7 +30,6 @@ class MailViewPage extends StatelessWidget {
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
                 children: [
                   _MailViewHeader(email: email),
                   const SizedBox(height: 32),

--- a/lib/studies/reply/model/email_model.dart
+++ b/lib/studies/reply/model/email_model.dart
@@ -8,7 +8,6 @@ class Email {
     this.recipients,
     this.hasAttachment,
     this.containsPictures,
-    this.isRead,
   });
 
   final String sender;
@@ -19,5 +18,4 @@ class Email {
   final String recipients;
   final bool hasAttachment;
   final bool containsPictures;
-  final bool isRead;
 }

--- a/lib/studies/reply/model/email_store.dart
+++ b/lib/studies/reply/model/email_store.dart
@@ -40,7 +40,6 @@ class EmailStore with ChangeNotifier {
       recipients: 'Jeff',
       hasAttachment: false,
       containsPictures: false,
-      isRead: false,
     ),
     const Email(
       sender: 'Allison Trabucco',

--- a/lib/studies/reply/model/email_store.dart
+++ b/lib/studies/reply/model/email_store.dart
@@ -26,7 +26,6 @@ class EmailStore with ChangeNotifier {
       recipients: 'Jeff',
       hasAttachment: true,
       containsPictures: false,
-      isRead: false,
     ),
     const Email(
       sender: 'Ali Connors',
@@ -52,7 +51,6 @@ class EmailStore with ChangeNotifier {
       recipients: 'Jeff',
       hasAttachment: false,
       containsPictures: true,
-      isRead: false,
     ),
     const Email(
       sender: 'Trevor Hansen',
@@ -70,7 +68,6 @@ class EmailStore with ChangeNotifier {
       recipients: 'Allison, Kim, Jeff',
       hasAttachment: false,
       containsPictures: false,
-      isRead: false,
     ),
     const Email(
       sender: 'Frank Hawkins',
@@ -81,7 +78,6 @@ class EmailStore with ChangeNotifier {
       recipients: 'Jeff',
       hasAttachment: false,
       containsPictures: false,
-      isRead: false,
     ),
     const Email(
       sender: 'Google Express',
@@ -92,7 +88,6 @@ class EmailStore with ChangeNotifier {
       recipients: 'Jeff',
       hasAttachment: false,
       containsPictures: false,
-      isRead: false,
     ),
   ];
 
@@ -111,7 +106,6 @@ class EmailStore with ChangeNotifier {
       recipients: 'Jeff',
       hasAttachment: false,
       containsPictures: false,
-      isRead: false,
     ),
     const Email(
       sender: 'Sandra Adams',
@@ -124,7 +118,6 @@ class EmailStore with ChangeNotifier {
       recipients: 'Jeff',
       hasAttachment: true,
       containsPictures: false,
-      isRead: false,
     ),
   ];
 
@@ -140,7 +133,6 @@ class EmailStore with ChangeNotifier {
       recipients: 'Jeff',
       hasAttachment: false,
       containsPictures: false,
-      isRead: false,
     ),
     const Email(
       sender: 'Allison Trabucco',
@@ -153,7 +145,6 @@ class EmailStore with ChangeNotifier {
       recipients: 'Jeff',
       hasAttachment: false,
       containsPictures: false,
-      isRead: false,
     ),
   ];
 
@@ -168,7 +159,6 @@ class EmailStore with ChangeNotifier {
       recipients: 'Jeff',
       hasAttachment: false,
       containsPictures: false,
-      isRead: false,
     ),
   ];
 
@@ -183,7 +173,6 @@ class EmailStore with ChangeNotifier {
       recipients: 'Jeff',
       hasAttachment: false,
       containsPictures: false,
-      isRead: false,
     ),
   ];
 

--- a/lib/studies/reply/profile_avatar.dart
+++ b/lib/studies/reply/profile_avatar.dart
@@ -16,11 +16,12 @@ class ProfileAvatar extends StatelessWidget {
       child: CircleAvatar(
         radius: radius,
         backgroundColor: Theme.of(context).cardColor,
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(radius),
+        child: ClipOval(
           child: Image.asset(
             avatar,
             package: 'flutter_gallery_assets',
+            height: 42,
+            width: 42,
             fit: BoxFit.cover,
           ),
         ),

--- a/lib/studies/reply/profile_avatar.dart
+++ b/lib/studies/reply/profile_avatar.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class ProfileAvatar extends StatelessWidget {
   const ProfileAvatar({
     @required this.avatar,
-    this.radius,
+    this.radius = 20,
   }) : assert(avatar != null);
 
   final String avatar;
@@ -15,11 +15,15 @@ class ProfileAvatar extends StatelessWidget {
       color: Colors.transparent,
       child: CircleAvatar(
         radius: radius,
-        backgroundImage: AssetImage(
-          avatar,
-          package: 'flutter_gallery_assets',
-        ),
         backgroundColor: Theme.of(context).cardColor,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(radius),
+          child: Image.asset(
+            avatar,
+            package: 'flutter_gallery_assets',
+            fit: BoxFit.cover,
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
* Implements `PictureGrid` class that returns a Grid of pictures to be displayed on the `MailView` if the email contains pictures e.g. `containsPictures = true`.
* Implements `PicturePreview` class that returns a `ListView` of pictures to be displayed on the `MailCardPreview` if the email contains pictures
* Removes unused `isRead` property from `Email` model
* Updates `MailPreview` to take in an `Email` object instead of separate email properties.

Picture Preview Desktop|Picture Preview Mobile
---|---
![Screen Shot 2020-08-19 at 8 45 00 PM](https://user-images.githubusercontent.com/948037/90714626-f3994c00-e25c-11ea-847a-84ff833491de.png)|![Screen Shot 2020-08-19 at 8 45 18 PM](https://user-images.githubusercontent.com/948037/90714632-f5fba600-e25c-11ea-9dae-b51635215b7c.png)

Picture Grid Desktop|Picture Grid Mobile
---|---
![Screen Shot 2020-08-19 at 8 45 22 PM](https://user-images.githubusercontent.com/948037/90714634-f7c56980-e25c-11ea-8302-1aa7a13f3ff9.png)|![Screen Shot 2020-08-19 at 8 45 31 PM](https://user-images.githubusercontent.com/948037/90714637-fa27c380-e25c-11ea-9e20-a385abf0d9e1.png)
