### PR TITLE
[Reply] Implement action bar logic

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -804,7 +804,12 @@ class _BottomAppBarActionItems extends StatelessWidget {
                               package: _assetsPackage,
                             ),
                           ),
-                          onPressed: () {},
+                          onPressed: () {
+                            model.starEmail(
+                              model.currentlySelectedInbox,
+                              model.currentlySelectedEmailId,
+                            );
+                          },
                           color: ReplyColors.white50,
                         ),
                         IconButton(
@@ -814,7 +819,13 @@ class _BottomAppBarActionItems extends StatelessWidget {
                               package: _assetsPackage,
                             ),
                           ),
-                          onPressed: () {},
+                          onPressed: () {
+                            mobileMailNavKey.currentState.pop();
+                            model.deleteEmail(
+                              model.currentlySelectedInbox,
+                              model.currentlySelectedEmailId,
+                            );
+                          },
                           color: ReplyColors.white50,
                         ),
                         IconButton(

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -1096,6 +1096,8 @@ class _FabSwitcher extends StatelessWidget {
 
   final bool onMailView;
 
+  static final fabKey = UniqueKey();
+
   @override
   Widget build(BuildContext context) {
     return AnimatedSwitcher(
@@ -1105,7 +1107,7 @@ class _FabSwitcher extends StatelessWidget {
         scale: animation,
       ),
       child: onMailView
-          ? Icon(Icons.reply_all, key: UniqueKey())
+          ? Icon(Icons.reply_all, key: fabKey)
           : const Icon(Icons.create),
     );
   }

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -179,7 +179,7 @@ class _MailPreview extends StatelessWidget {
           context,
           listen: false,
         ).currentlySelectedEmailId = id;
-        onTap.call();
+        onTap();
       },
       child: LayoutBuilder(
         builder: (context, constraints) {
@@ -301,7 +301,7 @@ class _MailPreviewActionBar extends StatelessWidget {
               ),
               color: color,
             ),
-            onPressed: () => onStar.call(),
+            onPressed: onStar,
           ),
           IconButton(
             icon: ImageIcon(
@@ -311,7 +311,7 @@ class _MailPreviewActionBar extends StatelessWidget {
               ),
               color: color,
             ),
-            onPressed: () => onDelete.call(),
+            onPressed: onDelete,
           ),
           IconButton(
             icon: Icon(

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -189,6 +189,7 @@ class _MailPreview extends StatelessWidget {
               padding: const EdgeInsets.all(20),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
                 children: [
                   Row(
                     mainAxisSize: MainAxisSize.max,
@@ -228,8 +229,15 @@ class _MailPreview extends StatelessWidget {
                     ),
                   ),
                   if (email.containsPictures) ...[
-                    const SizedBox(height: 20),
-                    const _PicturePreview(),
+                    Flexible(
+                      fit: FlexFit.loose,
+                      child: Column(
+                        children: const [
+                          SizedBox(height: 20),
+                          _PicturePreview(),
+                        ],
+                      ),
+                    ),
                   ],
                 ],
               ),

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -48,6 +48,8 @@ class MailPreviewCard extends StatelessWidget {
           id: id,
           email: email,
           onTap: openContainer,
+          onStar: onStar,
+          onDelete: onDelete,
         );
         final onStarredInbox = Provider.of<EmailStore>(
               context,
@@ -155,6 +157,8 @@ class _MailPreview extends StatelessWidget {
     @required this.id,
     @required this.email,
     @required this.onTap,
+    this.onStar,
+    this.onDelete,
   })  : assert(id != null),
         assert(email != null),
         assert(onTap != null);
@@ -162,6 +166,8 @@ class _MailPreview extends StatelessWidget {
   final int id;
   final Email email;
   final VoidCallback onTap;
+  final VoidCallback onStar;
+  final VoidCallback onDelete;
 
   @override
   Widget build(BuildContext context) {
@@ -205,6 +211,8 @@ class _MailPreview extends StatelessWidget {
                       ),
                       _MailPreviewActionBar(
                         avatar: email.avatar,
+                        onStar: onStar,
+                        onDelete: onDelete,
                       ),
                     ],
                   ),
@@ -258,9 +266,15 @@ class _PicturePreview extends StatelessWidget {
 }
 
 class _MailPreviewActionBar extends StatelessWidget {
-  const _MailPreviewActionBar({this.avatar});
+  const _MailPreviewActionBar({
+    @required this.avatar,
+    this.onStar,
+    this.onDelete,
+  }) : assert(avatar != null);
 
   final String avatar;
+  final VoidCallback onStar;
+  final VoidCallback onDelete;
 
   @override
   Widget build(BuildContext context) {
@@ -271,27 +285,34 @@ class _MailPreviewActionBar extends StatelessWidget {
     return Row(
       children: [
         if (isDesktop) ...[
-          ImageIcon(
-            const AssetImage(
-              '$_iconAssetLocation/twotone_star.png',
-              package: _assetsPackage,
+          IconButton(
+            icon: ImageIcon(
+              const AssetImage(
+                '$_iconAssetLocation/twotone_star.png',
+                package: _assetsPackage,
+              ),
+              color: color,
             ),
-            color: color,
+            onPressed: () => onStar.call(),
           ),
-          const SizedBox(width: 20),
-          ImageIcon(
-            const AssetImage(
-              '$_iconAssetLocation/twotone_delete.png',
-              package: _assetsPackage,
+          IconButton(
+            icon: ImageIcon(
+              const AssetImage(
+                '$_iconAssetLocation/twotone_delete.png',
+                package: _assetsPackage,
+              ),
+              color: color,
             ),
-            color: color,
+            onPressed: () => onDelete.call(),
           ),
-          const SizedBox(width: 20),
-          Icon(
-            Icons.more_vert,
-            color: color,
+          IconButton(
+            icon: Icon(
+              Icons.more_vert,
+              color: color,
+            ),
+            onPressed: () {},
           ),
-          const SizedBox(width: 16),
+          const SizedBox(width: 12),
         ],
         ProfileAvatar(avatar: avatar),
       ],


### PR DESCRIPTION
This change adds functionality to the `IconButton's` found in the contextual bottom app bar action items, and the action bar found in `MailPreviewCard` for desktop/tablets.
* Trash icon on mobile, pops the current `MailViewPage` and then removes the entry from the `EmailStore` and the `InboxPage` updates to reflect it.
* Trash icon on desktop/tablet, removes the selected entry from the `EmailStore` and updates the `InboxPage`
* Star icon on both desktop and mobile, adds the current email to the starred inbox

Misc Fixes:
* Fixes constant fab rebuild when consumer is notified, despite not changing context
* Fixes overflow error on `MailPreviewCard` in relation to `PicturePreview`