### PR TITLE
[Reply] Move back button position to top center

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -8,7 +8,6 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/semantics.dart';
-
 import 'package:gallery/constants.dart';
 import 'package:gallery/data/demos.dart';
 import 'package:gallery/data/gallery_options.dart';
@@ -1080,9 +1079,11 @@ class StudyWrapper extends StatefulWidget {
   const StudyWrapper({
     Key key,
     this.study,
+    this.alignment = AlignmentDirectional.bottomStart,
   }) : super(key: key);
 
   final Widget study;
+  final AlignmentDirectional alignment;
 
   @override
   _StudyWrapperState createState() => _StudyWrapperState();
@@ -1101,7 +1102,7 @@ class _StudyWrapperState extends State<StudyWrapper> {
             child: widget.study,
           ),
           Align(
-            alignment: AlignmentDirectional.bottomStart,
+            alignment: widget.alignment,
             child: Padding(
               padding: const EdgeInsets.all(16),
               child: Semantics(

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -5,8 +5,8 @@ import 'package:gallery/pages/demo.dart';
 import 'package:gallery/pages/home.dart';
 import 'package:gallery/studies/crane/app.dart';
 import 'package:gallery/studies/fortnightly/app.dart';
-import 'package:gallery/studies/reply/app.dart';
 import 'package:gallery/studies/rally/app.dart';
+import 'package:gallery/studies/reply/app.dart';
 import 'package:gallery/studies/shrine/app.dart';
 import 'package:gallery/studies/starter/app.dart';
 
@@ -60,7 +60,10 @@ class RouteConfiguration {
     ),
     Path(
       r'^' + ReplyApp.homeRoute,
-      (context, match) => const StudyWrapper(study: ReplyApp()),
+      (context, match) => const StudyWrapper(
+        alignment: AlignmentDirectional.topCenter,
+        study: ReplyApp(),
+      ),
     ),
     Path(
       r'^' + StarterApp.defaultRoute,


### PR DESCRIPTION
This change exposes the `alignment` property for the `StudyWrapper`, so studies can set their own back button position if needed. 
* `alignment` defaults to `bottomStart` which was the default before this change
* Solves issue on Reply study where the back button covers the bottom drawer toggle, making it difficult to slide out the bottom drawer.