### PR TITLE
[Reply] Add visual feedback for starring email through action bar 

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -780,6 +780,13 @@ class _BottomAppBarActionItems extends StatelessWidget {
     return Consumer<EmailStore>(
       builder: (context, model, child) {
         final onMailView = model.onMailView;
+        Color starIconColor;
+        if (onMailView) {
+          final currentEmailStarred = model.currentEmailisStarred;
+          starIconColor = currentEmailStarred
+              ? Theme.of(context).colorScheme.secondary
+              : ReplyColors.white50;
+        }
 
         return AnimatedSwitcher(
           duration: _kAnimationDuration,
@@ -804,11 +811,12 @@ class _BottomAppBarActionItems extends StatelessWidget {
                       mainAxisAlignment: MainAxisAlignment.end,
                       children: [
                         IconButton(
-                          icon: const ImageIcon(
-                            AssetImage(
+                          icon: ImageIcon(
+                            const AssetImage(
                               '$_iconAssetLocation/twotone_star.png',
                               package: _assetsPackage,
                             ),
+                            color: starIconColor,
                           ),
                           onPressed: () {
                             model.starEmail(

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -781,8 +781,17 @@ class _BottomAppBarActionItems extends StatelessWidget {
       builder: (context, model, child) {
         final onMailView = model.onMailView;
         Color starIconColor;
+
         if (onMailView) {
-          final currentEmailStarred = model.currentEmailisStarred;
+          var currentEmailStarred = false;
+
+          if (model.emails[model.currentlySelectedInbox].isNotEmpty) {
+            currentEmailStarred = model.isEmailStarred(
+              model.emails[model.currentlySelectedInbox]
+                  .elementAt(model.currentlySelectedEmailId),
+            );
+          }
+
           starIconColor = currentEmailStarred
               ? Theme.of(context).colorScheme.secondary
               : ReplyColors.white50;
@@ -823,6 +832,10 @@ class _BottomAppBarActionItems extends StatelessWidget {
                               model.currentlySelectedInbox,
                               model.currentlySelectedEmailId,
                             );
+                            if (model.currentlySelectedInbox == 'Starred') {
+                              mobileMailNavKey.currentState.pop();
+                              model.currentlySelectedEmailId = -1;
+                            }
                           },
                           color: ReplyColors.white50,
                         ),
@@ -834,11 +847,13 @@ class _BottomAppBarActionItems extends StatelessWidget {
                             ),
                           ),
                           onPressed: () {
-                            mobileMailNavKey.currentState.pop();
                             model.deleteEmail(
                               model.currentlySelectedInbox,
                               model.currentlySelectedEmailId,
                             );
+
+                            mobileMailNavKey.currentState.pop();
+                            model.currentlySelectedEmailId = -1;
                           },
                           color: ReplyColors.white50,
                         ),

--- a/lib/studies/reply/mail_card_preview.dart
+++ b/lib/studies/reply/mail_card_preview.dart
@@ -172,13 +172,14 @@ class _MailPreview extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    var emailStore = Provider.of<EmailStore>(
+      context,
+      listen: false,
+    );
 
     return InkWell(
       onTap: () {
-        Provider.of<EmailStore>(
-          context,
-          listen: false,
-        ).currentlySelectedEmailId = id;
+        emailStore.currentlySelectedEmailId = id;
         onTap.call();
       },
       child: LayoutBuilder(
@@ -212,6 +213,7 @@ class _MailPreview extends StatelessWidget {
                       ),
                       _MailPreviewActionBar(
                         avatar: email.avatar,
+                        isStarred: emailStore.isEmailStarred(email),
                         onStar: onStar,
                         onDelete: onDelete,
                       ),
@@ -276,11 +278,13 @@ class _PicturePreview extends StatelessWidget {
 class _MailPreviewActionBar extends StatelessWidget {
   const _MailPreviewActionBar({
     @required this.avatar,
+    this.isStarred,
     this.onStar,
     this.onDelete,
   }) : assert(avatar != null);
 
   final String avatar;
+  final bool isStarred;
   final VoidCallback onStar;
   final VoidCallback onDelete;
 
@@ -289,6 +293,8 @@ class _MailPreviewActionBar extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final color = isDark ? ReplyColors.white50 : ReplyColors.blue600;
     final isDesktop = isDisplayDesktop(context);
+    final starredIconColor =
+        isStarred ? Theme.of(context).colorScheme.secondary : color;
 
     return Row(
       children: [
@@ -299,7 +305,7 @@ class _MailPreviewActionBar extends StatelessWidget {
                 '$_iconAssetLocation/twotone_star.png',
                 package: _assetsPackage,
               ),
-              color: color,
+              color: starredIconColor,
             ),
             onPressed: () => onStar.call(),
           ),

--- a/lib/studies/reply/model/email_store.dart
+++ b/lib/studies/reply/model/email_store.dart
@@ -211,10 +211,10 @@ class EmailStore with ChangeNotifier {
   int get currentlySelectedEmailId => _currentlySelectedEmailId;
   String get currentlySelectedInbox => _currentlySelectedInbox;
   bool get onMailView => _currentlySelectedEmailId > -1;
-  bool get currentEmailisStarred => _categories['Starred'].contains(
-        _categories[currentlySelectedInbox].elementAt(currentlySelectedEmailId),
-      );
-  bool isEmailStarred(Email email) => _categories['Starred'].contains(email);
+
+  bool isEmailStarred(Email email) {
+    return _categories['Starred'].contains(email);
+  }
 
   set currentlySelectedEmailId(int value) {
     _currentlySelectedEmailId = value;

--- a/lib/studies/reply/model/email_store.dart
+++ b/lib/studies/reply/model/email_store.dart
@@ -211,6 +211,10 @@ class EmailStore with ChangeNotifier {
   int get currentlySelectedEmailId => _currentlySelectedEmailId;
   String get currentlySelectedInbox => _currentlySelectedInbox;
   bool get onMailView => _currentlySelectedEmailId > -1;
+  bool get currentEmailisStarred => _categories['Starred'].contains(
+        _categories[currentlySelectedInbox].elementAt(currentlySelectedEmailId),
+      );
+  bool isEmailStarred(Email email) => _categories['Starred'].contains(email);
 
   set currentlySelectedEmailId(int value) {
     _currentlySelectedEmailId = value;


### PR DESCRIPTION
This change adds visual feedback for starring an email through the action bar that is located on the `MailPreviewCard` on Desktop/tablet and `BottomActionBarItems` on Mobile.

* Adds function `isEmailStarred` to `EmailStore` that takes in an `Email` object and return whether that object is "Starred" e.g. is in the `Starred` inbox.
* Starred icon is `Theme.of(context).colorScheme.secondary` when enabled
* Clicking on starred icon while on the starred inbox will dismiss the item from the inbox
* Fixes contextual bottom app bar when returning to `InboxPage` from `MailViewPage` after using one of the action items.

Desktop|Mobile
---|---
![reply-star-feedback-desktop](https://user-images.githubusercontent.com/948037/91010324-257d1c00-e597-11ea-830f-1fe098df81ed.gif)|![reply-star-feedback-mob](https://user-images.githubusercontent.com/948037/91010344-2ca42a00-e597-11ea-8c59-2a6adbb68800.gif)
