### PR TITLE
[Reply] Utilize FadeThroughTransition for contextual bottom app bar

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -1083,7 +1083,7 @@ class _ReplyFabState extends State<_ReplyFab>
             if (isDesktop) {
               return AnimatedSize(
                 vsync: this,
-                curve: Curves.easeInOut,
+                curve: Curves.fastOutSlowIn,
                 duration: _kAnimationDuration,
                 child: FloatingActionButton.extended(
                   heroTag: 'Rail FAB',

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -794,7 +794,7 @@ class _BottomAppBarActionItems extends StatelessWidget {
         }
 
         return _FadeThroughTransitionSwitcher(
-          fillColor: Theme.of(context).navigationRailTheme.backgroundColor,
+          fillColor: Colors.transparent,
           child: drawerVisible
               ? Align(
                   key: UniqueKey(),

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -287,10 +287,7 @@ class _DesktopNavState extends State<_DesktopNav>
           const VerticalDivider(thickness: 1, width: 1),
           Expanded(
             child: _MailNavigator(
-              child: _FadeThroughTransitionSwitcher(
-                fillColor: Theme.of(context).scaffoldBackgroundColor,
-                child: widget.currentInbox,
-              ),
+              child: widget.currentInbox,
             ),
           ),
         ],
@@ -631,10 +628,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
         NotificationListener<ScrollNotification>(
           onNotification: _handleScrollNotification,
           child: _MailNavigator(
-            child: _FadeThroughTransitionSwitcher(
-              fillColor: Theme.of(context).scaffoldBackgroundColor,
-              child: widget.currentInbox,
-            ),
+            child: widget.currentInbox,
           ),
         ),
         GestureDetector(
@@ -1018,9 +1012,14 @@ class _MailNavigatorState extends State<_MailNavigator> {
     return Navigator(
       key: isDesktop ? desktopMailNavKey : mobileMailNavKey,
       onGenerateRoute: (settings) {
-        return MaterialPageRoute<void>(builder: (context) {
-          return widget.child;
-        });
+        return MaterialPageRoute<void>(
+          builder: (context) {
+            return _FadeThroughTransitionSwitcher(
+              fillColor: Theme.of(context).scaffoldBackgroundColor,
+              child: widget.child,
+            );
+          },
+        );
       },
     );
   }

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -1123,10 +1123,10 @@ class _ReplyFabState extends State<_ReplyFab>
 
 class _FadeThroughTransitionSwitcher extends StatelessWidget {
   const _FadeThroughTransitionSwitcher({
-    @required this.child,
     @required this.fillColor,
-  })  : assert(child != null),
-        assert(fillColor != null);
+    @required this.child,
+  })  : assert(fillColor != null),
+        assert(child != null);
 
   final Widget child;
   final Color fillColor;


### PR DESCRIPTION
Per feedback from Jonas, we should use a `FadeThroughTransition` for the contextual bottom app bar icons instead of a `ScaleTransition`.

This change deprecates `_InboxTransitionSwitcher` and `_FabSwitcher` in favor of a more common `_FadeThroughTransitionSwitcher`. 
* `_FadeThroughTransitionSwitcher` takes in a `child` which it transitions between and a `fillColor` that fills the transition.
* Make `_FadeThroughTransitionSwitcher` common to `_MailNavigator`
* Contextual bottom app bar actions and `_ReplyFab` now use `FadeThroughTransition`