### PR TITLE
[Reply] Update EmailStore to use a Set internally for inboxes instead of Lists

### DIFF
--- a/lib/studies/reply/compose_page.dart
+++ b/lib/studies/reply/compose_page.dart
@@ -16,7 +16,7 @@ class ComposePage extends StatelessWidget {
 
     if (emailStore.currentlySelectedEmailId >= 0) {
       final currentEmail = emailStore.emails[emailStore.currentlySelectedInbox]
-          [emailStore.currentlySelectedEmailId];
+          .elementAt(emailStore.currentlySelectedEmailId);
       _subject = currentEmail.subject;
       _recipient = currentEmail.sender;
       _recipientAvatar = currentEmail.avatar;

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -39,7 +39,7 @@ class InboxPage extends StatelessWidget {
                         index++) ...[
                       MailPreviewCard(
                         id: index,
-                        email: model.emails[destination][index],
+                        email: model.emails[destination].elementAt(index),
                         onDelete: () => model.deleteEmail(destination, index),
                         onStar: () => model.starEmail(destination, index),
                       ),

--- a/lib/studies/reply/model/email_store.dart
+++ b/lib/studies/reply/model/email_store.dart
@@ -5,7 +5,7 @@ import 'email_model.dart';
 const _avatarsLocation = 'reply/avatars';
 
 class EmailStore with ChangeNotifier {
-  final _categories = <String, List<Email>>{
+  final _categories = <String, Set<Email>>{
     'Inbox': _mainInbox,
     'Starred': _starredInbox,
     'Sent': _outbox,
@@ -14,7 +14,7 @@ class EmailStore with ChangeNotifier {
     'Drafts': _drafts,
   };
 
-  static final _mainInbox = <Email>[
+  static final _mainInbox = <Email>{
     const Email(
       sender: 'Google Express',
       time: '15 minutes ago',
@@ -88,11 +88,11 @@ class EmailStore with ChangeNotifier {
       hasAttachment: false,
       containsPictures: false,
     ),
-  ];
+  };
 
-  static final _starredInbox = <Email>[];
+  static final _starredInbox = <Email>{};
 
-  static final _outbox = <Email>[
+  static final _outbox = <Email>{
     const Email(
       sender: 'Kim Alen',
       time: '4 hrs ago',
@@ -118,9 +118,9 @@ class EmailStore with ChangeNotifier {
       hasAttachment: true,
       containsPictures: false,
     ),
-  ];
+  };
 
-  static final _trash = <Email>[
+  static final _trash = <Email>{
     const Email(
       sender: 'Frank Hawkins',
       time: '4 hrs ago',
@@ -145,9 +145,9 @@ class EmailStore with ChangeNotifier {
       hasAttachment: false,
       containsPictures: false,
     ),
-  ];
+  };
 
-  static final _spam = <Email>[
+  static final _spam = <Email>{
     const Email(
       sender: 'Allison Trabucco',
       time: '4 hrs ago',
@@ -159,9 +159,9 @@ class EmailStore with ChangeNotifier {
       hasAttachment: false,
       containsPictures: false,
     ),
-  ];
+  };
 
-  static final _drafts = <Email>[
+  static final _drafts = <Email>{
     const Email(
       sender: 'Sandra Adams',
       time: '2 hrs ago',
@@ -173,31 +173,31 @@ class EmailStore with ChangeNotifier {
       hasAttachment: false,
       containsPictures: false,
     ),
-  ];
+  };
 
   int _currentlySelectedEmailId = -1;
   String _currentlySelectedInbox = 'Inbox';
 
-  Map<String, List<Email>> get emails =>
-      Map<String, List<Email>>.unmodifiable(_categories);
+  Map<String, Set<Email>> get emails =>
+      Map<String, Set<Email>>.unmodifiable(_categories);
 
   void deleteEmail(String category, int id) {
     final email = _categories[category].elementAt(id);
 
-    _categories[category].removeAt(id);
-
-    _categories.forEach((key, value) {
-      if (value.contains(email)) {
-        value.remove(email);
-      }
-    });
+    _categories.forEach(
+      (key, value) {
+        if (value.contains(email)) {
+          value.remove(email);
+        }
+      },
+    );
 
     notifyListeners();
   }
 
   void starEmail(String category, int id) {
     final email = _categories[category].elementAt(id);
-    var alreadyStarred = _categories['Starred'].contains(email);
+    var alreadyStarred = isEmailStarred(email);
 
     if (alreadyStarred) {
       _categories['Starred'].remove(email);


### PR DESCRIPTION
The default `Set` implementation in dart is a `LinkedHashSet` which keeps insertion order, allowing us to access our elements by index like we were doing with our `List`. It also gives us the advantage of having `O(1)` lookup, which our `EmailStore` utilizes when deleting emails, starring emails, and checking if an email is starred. This performance difference generally doesn't matter for smaller data sets, but as our `n` in our data set increases, that performance boost becomes more important.