### PR TITLE
[Reply] Workaround for mobile fab open container a11y states issue

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -1087,18 +1087,15 @@ class _ReplyFabState extends State<_ReplyFab>
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
     final theme = Theme.of(context);
-    final mobileFabBorder = const RoundedRectangleBorder(
-      borderRadius: BorderRadius.all(Radius.circular(_mobileFabDimension / 2)),
-    );
+    final circleFabBorder = const CircleBorder();
 
     return OpenContainer(
       openBuilder: (context, closedContainer) {
         return const ComposePage();
       },
       openColor: theme.cardColor,
-      closedShape: isDesktop & widget.extended
-          ? const StadiumBorder()
-          : isDesktop ? const CircleBorder() : mobileFabBorder,
+      closedShape:
+          isDesktop & widget.extended ? const StadiumBorder() : circleFabBorder,
       closedColor: theme.colorScheme.secondary,
       closedElevation: 6,
       closedBuilder: (context, openContainer) {
@@ -1147,14 +1144,17 @@ class _ReplyFabState extends State<_ReplyFab>
                 ),
               );
             } else {
-              return InkWell(
-                customBorder: mobileFabBorder,
-                onTap: openContainer,
-                child: SizedBox(
-                  height: _mobileFabDimension,
-                  width: _mobileFabDimension,
-                  child: Center(
-                    child: fabSwitcher,
+              return Tooltip(
+                message: tooltip,
+                child: InkWell(
+                  customBorder: circleFabBorder,
+                  onTap: openContainer,
+                  child: SizedBox(
+                    height: _mobileFabDimension,
+                    width: _mobileFabDimension,
+                    child: Center(
+                      child: fabSwitcher,
+                    ),
                   ),
                 ),
               );

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -1081,11 +1081,15 @@ class _ReplyFab extends StatefulWidget {
 class _ReplyFabState extends State<_ReplyFab>
     with SingleTickerProviderStateMixin {
   static final fabKey = UniqueKey();
+  static const double _mobileFabDimension = 56;
 
   @override
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
     final theme = Theme.of(context);
+    final mobileFabBorder = const RoundedRectangleBorder(
+      borderRadius: BorderRadius.all(Radius.circular(_mobileFabDimension / 2)),
+    );
 
     return OpenContainer(
       openBuilder: (context, closedContainer) {
@@ -1094,17 +1098,25 @@ class _ReplyFabState extends State<_ReplyFab>
       openColor: theme.cardColor,
       closedShape: isDesktop & widget.extended
           ? const StadiumBorder()
-          : const CircleBorder(),
+          : isDesktop ? const CircleBorder() : mobileFabBorder,
       closedColor: theme.colorScheme.secondary,
+      closedElevation: 6,
       closedBuilder: (context, openContainer) {
         return Consumer<EmailStore>(
           builder: (context, model, child) {
             final onMailView = model.onMailView;
             final fabSwitcher = _FadeThroughTransitionSwitcher(
-              fillColor: Theme.of(context).colorScheme.secondary,
+              fillColor: Colors.transparent,
               child: onMailView
-                  ? Icon(Icons.reply_all, key: fabKey)
-                  : const Icon(Icons.create),
+                  ? Icon(
+                      Icons.reply_all,
+                      key: fabKey,
+                      color: Colors.black,
+                    )
+                  : const Icon(
+                      Icons.create,
+                      color: Colors.black,
+                    ),
             );
             final tooltip = onMailView ? 'Reply' : 'Compose';
 
@@ -1135,11 +1147,16 @@ class _ReplyFabState extends State<_ReplyFab>
                 ),
               );
             } else {
-              return FloatingActionButton(
-                heroTag: 'Bottom App Bar FAB',
-                tooltip: tooltip,
-                child: fabSwitcher,
-                onPressed: openContainer,
+              return InkWell(
+                customBorder: mobileFabBorder,
+                onTap: openContainer,
+                child: SizedBox(
+                  height: _mobileFabDimension,
+                  width: _mobileFabDimension,
+                  child: Center(
+                    child: fabSwitcher,
+                  ),
+                ),
               );
             }
           },


### PR DESCRIPTION
This change implements a workaround for the open container a11y states issue. As shown in the screenshot below when using the open container transform with interactive/existing widgets, the widgets visual states overlap. This only apply's to the mobile fab, since the desktop fab will no longer use open container transform, per feedback from Jonas.

This change replaces the `FloatingActionButton` with a `SizedBox()` implementation.
This change should be reverted when a fix for the a11y states issue is merged.

Before|After
---|---
![Screenshot_20200824-122700](https://user-images.githubusercontent.com/948037/91208274-ce726680-e6be-11ea-9536-4e18424310c0.jpg)|![Screen Shot 2020-08-25 at 10 20 44 AM](https://user-images.githubusercontent.com/948037/91208236-c286a480-e6be-11ea-91d6-a06cf0094720.png)
