### PR TITLE
[Reply] Update desktop ComposePage/SearchPage to only take up MailNavigator area

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -128,7 +128,7 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
     emailStore.currentlySelectedInbox = destination;
 
     if (isDesktop) {
-      if (desktopMailNavKey.currentState.canPop()) {
+      while (desktopMailNavKey.currentState.canPop()) {
         desktopMailNavKey.currentState.pop();
       }
     }

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -1035,15 +1035,27 @@ class _MailNavigatorState extends State<_MailNavigator> {
 
     return Navigator(
       key: isDesktop ? desktopMailNavKey : mobileMailNavKey,
+      initialRoute: ReplyApp.homeRoute,
       onGenerateRoute: (settings) {
-        return MaterialPageRoute<void>(
-          builder: (context) {
-            return _FadeThroughTransitionSwitcher(
-              fillColor: Theme.of(context).scaffoldBackgroundColor,
-              child: widget.child,
+        switch (settings.name) {
+          case ReplyApp.homeRoute:
+            return MaterialPageRoute<void>(
+              builder: (context) {
+                return _FadeThroughTransitionSwitcher(
+                  fillColor: Theme.of(context).scaffoldBackgroundColor,
+                  child: widget.child,
+                );
+              },
             );
-          },
-        );
+            break;
+          case ReplyApp.searchRoute:
+            return ReplyApp.createSearchRoute();
+            break;
+          case ReplyApp.composeRoute:
+            return ReplyApp.createComposeRoute();
+            break;
+        }
+        return null;
       },
     );
   }
@@ -1079,21 +1091,6 @@ class _ReplyFabState extends State<_ReplyFab>
   static final fabKey = UniqueKey();
   static const double _mobileFabDimension = 56;
 
-  Route _createComposeRoute() {
-    return PageRouteBuilder<void>(
-      pageBuilder: (context, animation, secondaryAnimation) =>
-          const ComposePage(),
-      transitionsBuilder: (context, animation, secondaryAnimation, child) {
-        return FadeThroughTransition(
-          fillColor: Theme.of(context).cardColor,
-          animation: animation,
-          secondaryAnimation: secondaryAnimation,
-          child: child,
-        );
-      },
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
@@ -1123,8 +1120,8 @@ class _ReplyFabState extends State<_ReplyFab>
             heroTag: 'Rail FAB',
             tooltip: tooltip,
             isExtended: widget.extended,
-            onPressed: () => desktopMailNavKey.currentState
-                .push<void>(_createComposeRoute()),
+            onPressed: () =>
+                desktopMailNavKey.currentState.pushNamed(ReplyApp.composeRoute),
             label: Row(
               children: [
                 fabSwitcher,

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -1118,15 +1118,15 @@ class _ReplyFabState extends State<_ReplyFab>
         if (isDesktop) {
           return FloatingActionButton.extended(
             heroTag: 'Rail FAB',
-            tooltip: tooltip,
+            tooltip: widget.extended ? null : tooltip,
             isExtended: widget.extended,
             onPressed: () =>
                 desktopMailNavKey.currentState.pushNamed(ReplyApp.composeRoute),
             label: Row(
               children: [
                 fabSwitcher,
-                SizedBox(width: widget.extended ? 16 : 0),
-                if (widget.extended)
+                if (widget.extended) ...[
+                  const SizedBox(width: 16),
                   Text(
                     tooltip.toUpperCase(),
                     style: Theme.of(context).textTheme.headline5.copyWith(
@@ -1134,6 +1134,7 @@ class _ReplyFabState extends State<_ReplyFab>
                           color: theme.colorScheme.onSecondary,
                         ),
                   ),
+                ]
               ],
             ),
           );

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -96,7 +96,7 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
     if (isDesktop) {
       return _DesktopNav(
         selectedIndex: _selectedIndex,
-        currentScreen: _currentInbox,
+        currentInbox: _currentInbox,
         extended: isTablet ? false : true,
         destinations: _navigationDestinations,
         folders: _folders,
@@ -155,7 +155,7 @@ class _DesktopNav extends StatefulWidget {
   const _DesktopNav({
     Key key,
     this.selectedIndex,
-    this.currentScreen,
+    this.currentInbox,
     this.extended,
     this.destinations,
     this.folders,
@@ -164,7 +164,7 @@ class _DesktopNav extends StatefulWidget {
 
   final int selectedIndex;
   final bool extended;
-  final Widget currentScreen;
+  final Widget currentInbox;
   final List<_Destination> destinations;
   final Map<String, String> folders;
   final void Function(int, String) onItemTapped;
@@ -291,7 +291,7 @@ class _DesktopNavState extends State<_DesktopNav>
           const VerticalDivider(thickness: 1, width: 1),
           Expanded(
             child: _MailNavigator(
-              child: widget.currentScreen,
+              child: widget.currentInbox,
             ),
           ),
         ],

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -1123,8 +1123,25 @@ class _ReplyFabState extends State<_ReplyFab>
             heroTag: 'Rail FAB',
             tooltip: widget.extended ? null : tooltip,
             isExtended: widget.extended,
-            onPressed: () =>
-                desktopMailNavKey.currentState.pushNamed(ReplyApp.composeRoute),
+            onPressed: () {
+              // Navigator does not have an easy way to access the current
+              // route when using a GlobalKey to keep track of NavigatorState.
+              // We can use [Navigator.popUntil] in order to access the current
+              // route, and check if it is either a ComposePage or a SearchPage.
+              // If it is neither, then we can push a ComposePage onto our
+              // navigator. We return true at the end so nothing is popped.
+              desktopMailNavKey.currentState.popUntil(
+                (route) {
+                  var currentRoute = route.settings.name;
+                  if (currentRoute != ReplyApp.composeRoute &&
+                      currentRoute != ReplyApp.searchRoute) {
+                    desktopMailNavKey.currentState
+                        .pushNamed(ReplyApp.composeRoute);
+                  }
+                  return true;
+                },
+              );
+            },
             label: Row(
               children: [
                 fabSwitcher,

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -97,7 +97,7 @@ class _AdaptiveNavState extends State<AdaptiveNav> {
       return _DesktopNav(
         selectedIndex: _selectedIndex,
         currentInbox: _currentInbox,
-        extended: isTablet ? false : true,
+        extended: !isTablet ? true : false,
         destinations: _navigationDestinations,
         folders: _folders,
         onItemTapped: _onDestinationSelected,
@@ -1029,16 +1029,18 @@ class _MailNavigator extends StatefulWidget {
 }
 
 class _MailNavigatorState extends State<_MailNavigator> {
+  static const inboxRoute = '/reply/inbox';
+
   @override
   Widget build(BuildContext context) {
     final isDesktop = isDisplayDesktop(context);
 
     return Navigator(
       key: isDesktop ? desktopMailNavKey : mobileMailNavKey,
-      initialRoute: ReplyApp.homeRoute,
+      initialRoute: inboxRoute,
       onGenerateRoute: (settings) {
         switch (settings.name) {
-          case ReplyApp.homeRoute:
+          case inboxRoute:
             return MaterialPageRoute<void>(
               builder: (context) {
                 return _FadeThroughTransitionSwitcher(
@@ -1046,13 +1048,14 @@ class _MailNavigatorState extends State<_MailNavigator> {
                   child: widget.child,
                 );
               },
+              settings: settings,
             );
             break;
           case ReplyApp.searchRoute:
-            return ReplyApp.createSearchRoute();
+            return ReplyApp.createSearchRoute(settings);
             break;
           case ReplyApp.composeRoute:
-            return ReplyApp.createComposeRoute();
+            return ReplyApp.createComposeRoute(settings);
             break;
         }
         return null;

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -20,7 +20,7 @@ class ReplyApp extends StatelessWidget {
   static const String searchRoute = '/reply/search';
   static const String composeRoute = '/reply/compose';
 
-  static Route createSearchRoute() {
+  static Route createSearchRoute(RouteSettings settings) {
     return PageRouteBuilder<void>(
       pageBuilder: (context, animation, secondaryAnimation) =>
           const SearchPage(),
@@ -33,10 +33,11 @@ class ReplyApp extends StatelessWidget {
           child: child,
         );
       },
+      settings: settings,
     );
   }
 
-  static Route createComposeRoute() {
+  static Route createComposeRoute(RouteSettings settings) {
     return PageRouteBuilder<void>(
       pageBuilder: (context, animation, secondaryAnimation) =>
           const ComposePage(),
@@ -48,6 +49,7 @@ class ReplyApp extends StatelessWidget {
           child: child,
         );
       },
+      settings: settings,
     );
   }
 
@@ -79,13 +81,14 @@ class ReplyApp extends StatelessWidget {
             case homeRoute:
               return MaterialPageRoute<void>(
                 builder: (context) => const AdaptiveNav(),
+                settings: settings,
               );
               break;
             case searchRoute:
-              return createSearchRoute();
+              return createSearchRoute(settings);
               break;
             case composeRoute:
-              return createComposeRoute();
+              return createComposeRoute(settings);
               break;
           }
           return null;

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -5,6 +5,7 @@ import 'package:gallery/l10n/gallery_localizations.dart';
 import 'package:gallery/layout/letter_spacing.dart';
 import 'package:gallery/studies/reply/adaptive_nav.dart';
 import 'package:gallery/studies/reply/colors.dart';
+import 'package:gallery/studies/reply/compose_page.dart';
 import 'package:gallery/studies/reply/model/email_store.dart';
 import 'package:gallery/studies/reply/search_page.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -17,6 +18,38 @@ class ReplyApp extends StatelessWidget {
 
   static const String homeRoute = '/reply';
   static const String searchRoute = '/reply/search';
+  static const String composeRoute = '/reply/compose';
+
+  static Route createSearchRoute() {
+    return PageRouteBuilder<void>(
+      pageBuilder: (context, animation, secondaryAnimation) =>
+          const SearchPage(),
+      transitionsBuilder: (context, animation, secondaryAnimation, child) {
+        return SharedAxisTransition(
+          fillColor: Theme.of(context).cardColor,
+          animation: animation,
+          secondaryAnimation: secondaryAnimation,
+          transitionType: SharedAxisTransitionType.scaled,
+          child: child,
+        );
+      },
+    );
+  }
+
+  static Route createComposeRoute() {
+    return PageRouteBuilder<void>(
+      pageBuilder: (context, animation, secondaryAnimation) =>
+          const ComposePage(),
+      transitionsBuilder: (context, animation, secondaryAnimation, child) {
+        return FadeThroughTransition(
+          fillColor: Theme.of(context).cardColor,
+          animation: animation,
+          secondaryAnimation: secondaryAnimation,
+          child: child,
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -43,6 +76,8 @@ class ReplyApp extends StatelessWidget {
         initialRoute: homeRoute,
         routes: <String, WidgetBuilder>{
           homeRoute: (context) => const AdaptiveNav(),
+          searchRoute: (context) => const SearchPage(),
+          composeRoute: (context) => const ComposePage(),
         },
         onGenerateRoute: (settings) {
           switch (settings.name) {
@@ -52,21 +87,10 @@ class ReplyApp extends StatelessWidget {
               );
               break;
             case searchRoute:
-              return PageRouteBuilder<void>(
-                pageBuilder: (context, animation, secondaryAnimation) {
-                  return const SearchPage();
-                },
-                transitionsBuilder:
-                    (context, animation, secondaryAnimation, child) {
-                  return SharedAxisTransition(
-                    fillColor: Theme.of(context).cardColor,
-                    transitionType: SharedAxisTransitionType.scaled,
-                    child: child,
-                    animation: animation,
-                    secondaryAnimation: secondaryAnimation,
-                  );
-                },
-              );
+              return createSearchRoute();
+              break;
+            case composeRoute:
+              return createComposeRoute();
               break;
           }
           return null;

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -74,11 +74,6 @@ class ReplyApp extends StatelessWidget {
         supportedLocales: GalleryLocalizations.supportedLocales,
         locale: GalleryOptions.of(context).locale,
         initialRoute: homeRoute,
-        routes: <String, WidgetBuilder>{
-          homeRoute: (context) => const AdaptiveNav(),
-          searchRoute: (context) => const SearchPage(),
-          composeRoute: (context) => const ComposePage(),
-        },
         onGenerateRoute: (settings) {
           switch (settings.name) {
             case homeRoute:

--- a/lib/studies/reply/compose_page.dart
+++ b/lib/studies/reply/compose_page.dart
@@ -73,7 +73,6 @@ class _SubjectRow extends StatefulWidget {
   const _SubjectRow({@required this.subject}) : assert(subject != null);
 
   final String subject;
-
   @override
   _SubjectRowState createState() => _SubjectRowState();
 }

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:gallery/layout/adaptive.dart';
+import 'package:gallery/studies/reply/adaptive_nav.dart';
 import 'package:gallery/studies/reply/app.dart';
 import 'package:gallery/studies/reply/mail_card_preview.dart';
 import 'package:gallery/studies/reply/model/email_store.dart';
@@ -57,7 +58,7 @@ class InboxPage extends StatelessWidget {
                       IconButton(
                         icon: const Icon(Icons.search),
                         onPressed: () {
-                          rootNavKey.currentState.pushNamed(
+                          desktopMailNavKey.currentState.pushNamed(
                             ReplyApp.searchRoute,
                           );
                         },


### PR DESCRIPTION
This change removes the implementation of the open container transform between the FAB and ComposePage on desktop. Instead we use a `FadeThroughTransition` to transition the area to the right of the navigation rail, from `InboxPage` or `MailViewPage` to the `ComposePage`. Similarly, with this change the `SearchPage` also only takes up the area to the right of the navigation rail, where previously it took up the whole canvas. 

* Implemented named route navigation for the `MailNavigator`
   * `createComposeRoute()` to create a `Route` for the `ComposePage` using `PageRouteBuilder`
   * `createSearchRoute()` to create a `Route` for the `SearchPage` using `PageRouteBuilder`
   *  Implemented `onGenerateRoute` for `MailNavigator`
   *  Initial route is `InboxPage`

Before|After
---|---
![reply-before-compose](https://user-images.githubusercontent.com/948037/91251662-c17e6300-e710-11ea-9153-c8f6c8331953.gif)|![reply-deskto-compose-revamp](https://user-images.githubusercontent.com/948037/91251427-49b03880-e710-11ea-8c69-2699baf09ea9.gif)
