### PR TITLE
[Reply] Fix Home <-> SearchPage transition, home page not fading through

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -13,6 +13,7 @@ import 'package:gallery/studies/reply/compose_page.dart';
 import 'package:gallery/studies/reply/inbox.dart';
 import 'package:gallery/studies/reply/model/email_store.dart';
 import 'package:gallery/studies/reply/profile_avatar.dart';
+import 'package:gallery/studies/reply/search_page.dart';
 import 'package:provider/provider.dart';
 
 const _assetsPackage = 'flutter_gallery_assets';
@@ -290,8 +291,10 @@ class _DesktopNavState extends State<_DesktopNav>
           ),
           const VerticalDivider(thickness: 1, width: 1),
           Expanded(
-            child: _MailNavigator(
-              child: widget.currentInbox,
+            child: _SharedAxisTransitionSwitcher(
+              defaultChild: _MailNavigator(
+                child: widget.currentInbox,
+              ),
             ),
           ),
         ],
@@ -701,92 +704,95 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      extendBody: true,
-      body: LayoutBuilder(
-        builder: _buildStack,
-      ),
-      bottomNavigationBar: Consumer<EmailStore>(
-        builder: (context, model, child) {
-          _bottomAppBarController.forward();
+    return _SharedAxisTransitionSwitcher(
+      defaultChild: Scaffold(
+        extendBody: true,
+        body: LayoutBuilder(
+          builder: _buildStack,
+        ),
+        bottomNavigationBar: Consumer<EmailStore>(
+          builder: (context, model, child) {
+            _bottomAppBarController.forward();
 
-          return SizeTransition(
-            sizeFactor: _bottomAppBarCurve,
-            axisAlignment: -1,
-            child: BottomAppBar(
-              shape: const CircularNotchedRectangle(),
-              notchMargin: 8,
-              child: SizedBox(
-                height: kToolbarHeight,
-                child: Row(
-                  mainAxisSize: MainAxisSize.max,
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    InkWell(
-                      borderRadius: const BorderRadius.all(Radius.circular(16)),
-                      onTap: _toggleBottomDrawerVisibility,
-                      child: Row(
-                        children: [
-                          const SizedBox(width: 16),
-                          RotationTransition(
-                            turns: Tween(
-                              begin: 0.0,
-                              end: 1.0,
-                            ).animate(_dropArrowCurve),
-                            child: const Icon(
-                              Icons.arrow_drop_up,
-                              color: ReplyColors.white50,
+            return SizeTransition(
+              sizeFactor: _bottomAppBarCurve,
+              axisAlignment: -1,
+              child: BottomAppBar(
+                shape: const CircularNotchedRectangle(),
+                notchMargin: 8,
+                child: SizedBox(
+                  height: kToolbarHeight,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.max,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      InkWell(
+                        borderRadius:
+                            const BorderRadius.all(Radius.circular(16)),
+                        onTap: _toggleBottomDrawerVisibility,
+                        child: Row(
+                          children: [
+                            const SizedBox(width: 16),
+                            RotationTransition(
+                              turns: Tween(
+                                begin: 0.0,
+                                end: 1.0,
+                              ).animate(_dropArrowCurve),
+                              child: const Icon(
+                                Icons.arrow_drop_up,
+                                color: ReplyColors.white50,
+                              ),
                             ),
-                          ),
-                          const SizedBox(width: 8),
-                          const _ReplyLogo(),
-                          const SizedBox(width: 10),
-                          Consumer<EmailStore>(
-                            builder: (context, model, child) {
-                              final onMailView = model.onMailView;
+                            const SizedBox(width: 8),
+                            const _ReplyLogo(),
+                            const SizedBox(width: 10),
+                            Consumer<EmailStore>(
+                              builder: (context, model, child) {
+                                final onMailView = model.onMailView;
 
-                              return AnimatedOpacity(
-                                opacity: _bottomDrawerVisible || onMailView
-                                    ? 0.0
-                                    : 1.0,
-                                duration: _kAnimationDuration,
-                                curve: Curves.fastOutSlowIn,
-                                child: Text(
-                                  widget
-                                      .destinations[widget.selectedIndex].name,
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .bodyText1
-                                      .copyWith(color: ReplyColors.white50),
-                                ),
-                              );
-                            },
-                          ),
-                        ],
-                      ),
-                    ),
-                    Expanded(
-                      child: Container(
-                        color: Colors.transparent,
-                        child: _BottomAppBarActionItems(
-                          drawerVisible: _bottomDrawerVisible,
+                                return AnimatedOpacity(
+                                  opacity: _bottomDrawerVisible || onMailView
+                                      ? 0.0
+                                      : 1.0,
+                                  duration: _kAnimationDuration,
+                                  curve: Curves.fastOutSlowIn,
+                                  child: Text(
+                                    widget.destinations[widget.selectedIndex]
+                                        .name,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .bodyText1
+                                        .copyWith(color: ReplyColors.white50),
+                                  ),
+                                );
+                              },
+                            ),
+                          ],
                         ),
                       ),
-                    ),
-                  ],
+                      Expanded(
+                        child: Container(
+                          color: Colors.transparent,
+                          child: _BottomAppBarActionItems(
+                            drawerVisible: _bottomDrawerVisible,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ),
-          );
-        },
+            );
+          },
+        ),
+        floatingActionButton: _bottomDrawerVisible
+            ? null
+            : const Padding(
+                padding: EdgeInsetsDirectional.only(bottom: 8),
+                child: _ReplyFab(),
+              ),
+        floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       ),
-      floatingActionButton: _bottomDrawerVisible
-          ? null
-          : const Padding(
-              padding: EdgeInsetsDirectional.only(bottom: 8),
-              child: _ReplyFab(),
-            ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
     );
   }
 }
@@ -887,10 +893,10 @@ class _BottomAppBarActionItems extends StatelessWidget {
                         icon: const Icon(Icons.search),
                         color: ReplyColors.white50,
                         onPressed: () {
-                          Navigator.pushNamed(
+                          Provider.of<EmailStore>(
                             context,
-                            ReplyApp.searchRoute,
-                          );
+                            listen: false,
+                          ).onSearchPage = true;
                         },
                       ),
                     ),
@@ -1051,9 +1057,6 @@ class _MailNavigatorState extends State<_MailNavigator> {
               settings: settings,
             );
             break;
-          case ReplyApp.searchRoute:
-            return ReplyApp.createSearchRoute(settings);
-            break;
           case ReplyApp.composeRoute:
             return ReplyApp.createComposeRoute(settings);
             break;
@@ -1124,17 +1127,21 @@ class _ReplyFabState extends State<_ReplyFab>
             tooltip: widget.extended ? null : tooltip,
             isExtended: widget.extended,
             onPressed: () {
+              var onSearchPage = Provider.of<EmailStore>(
+                context,
+                listen: false,
+              ).onSearchPage;
               // Navigator does not have an easy way to access the current
               // route when using a GlobalKey to keep track of NavigatorState.
               // We can use [Navigator.popUntil] in order to access the current
-              // route, and check if it is either a ComposePage or a SearchPage.
-              // If it is neither, then we can push a ComposePage onto our
-              // navigator. We return true at the end so nothing is popped.
+              // route, and check if it is a ComposePage. If it is not a
+              // ComposePage and we are not on the SearchPage, then we can push
+              // a ComposePage onto our navigator. We return true at the end
+              // so nothing is popped.
               desktopMailNavKey.currentState.popUntil(
                 (route) {
                   var currentRoute = route.settings.name;
-                  if (currentRoute != ReplyApp.composeRoute &&
-                      currentRoute != ReplyApp.searchRoute) {
+                  if (currentRoute != ReplyApp.composeRoute && !onSearchPage) {
                     desktopMailNavKey.currentState
                         .pushNamed(ReplyApp.composeRoute);
                   }
@@ -1212,6 +1219,36 @@ class _FadeThroughTransitionSwitcher extends StatelessWidget {
         );
       },
       child: child,
+    );
+  }
+}
+
+class _SharedAxisTransitionSwitcher extends StatelessWidget {
+  const _SharedAxisTransitionSwitcher({
+    @required this.defaultChild,
+  }) : assert(defaultChild != null);
+
+  final Widget defaultChild;
+
+  @override
+  Widget build(BuildContext context) {
+    return Selector<EmailStore, bool>(
+      builder: (context, onSearchPage, child) {
+        return PageTransitionSwitcher(
+          reverse: !onSearchPage,
+          transitionBuilder: (child, animation, secondaryAnimation) {
+            return SharedAxisTransition(
+              fillColor: Theme.of(context).cardColor,
+              animation: animation,
+              secondaryAnimation: secondaryAnimation,
+              transitionType: SharedAxisTransitionType.scaled,
+              child: child,
+            );
+          },
+          child: onSearchPage ? const SearchPage() : defaultChild,
+        );
+      },
+      selector: (context, emailStore) => emailStore.onSearchPage,
     );
   }
 }

--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -1233,6 +1233,7 @@ class _SharedAxisTransitionSwitcher extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Selector<EmailStore, bool>(
+      selector: (context, emailStore) => emailStore.onSearchPage,
       builder: (context, onSearchPage, child) {
         return PageTransitionSwitcher(
           reverse: !onSearchPage,
@@ -1248,7 +1249,6 @@ class _SharedAxisTransitionSwitcher extends StatelessWidget {
           child: onSearchPage ? const SearchPage() : defaultChild,
         );
       },
-      selector: (context, emailStore) => emailStore.onSearchPage,
     );
   }
 }

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -7,7 +7,6 @@ import 'package:gallery/studies/reply/adaptive_nav.dart';
 import 'package:gallery/studies/reply/colors.dart';
 import 'package:gallery/studies/reply/compose_page.dart';
 import 'package:gallery/studies/reply/model/email_store.dart';
-import 'package:gallery/studies/reply/search_page.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 
@@ -17,25 +16,7 @@ class ReplyApp extends StatelessWidget {
   const ReplyApp();
 
   static const String homeRoute = '/reply';
-  static const String searchRoute = '/reply/search';
   static const String composeRoute = '/reply/compose';
-
-  static Route createSearchRoute(RouteSettings settings) {
-    return PageRouteBuilder<void>(
-      pageBuilder: (context, animation, secondaryAnimation) =>
-          const SearchPage(),
-      transitionsBuilder: (context, animation, secondaryAnimation, child) {
-        return SharedAxisTransition(
-          fillColor: Theme.of(context).cardColor,
-          animation: animation,
-          secondaryAnimation: secondaryAnimation,
-          transitionType: SharedAxisTransitionType.scaled,
-          child: child,
-        );
-      },
-      settings: settings,
-    );
-  }
 
   static Route createComposeRoute(RouteSettings settings) {
     return PageRouteBuilder<void>(
@@ -83,9 +64,6 @@ class ReplyApp extends StatelessWidget {
                 builder: (context) => const AdaptiveNav(),
                 settings: settings,
               );
-              break;
-            case searchRoute:
-              return createSearchRoute(settings);
               break;
             case composeRoute:
               return createComposeRoute(settings);

--- a/lib/studies/reply/inbox.dart
+++ b/lib/studies/reply/inbox.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:gallery/layout/adaptive.dart';
-import 'package:gallery/studies/reply/adaptive_nav.dart';
-import 'package:gallery/studies/reply/app.dart';
 import 'package:gallery/studies/reply/mail_card_preview.dart';
 import 'package:gallery/studies/reply/model/email_store.dart';
 import 'package:provider/provider.dart';
@@ -58,9 +56,10 @@ class InboxPage extends StatelessWidget {
                       IconButton(
                         icon: const Icon(Icons.search),
                         onPressed: () {
-                          desktopMailNavKey.currentState.pushNamed(
-                            ReplyApp.searchRoute,
-                          );
+                          Provider.of<EmailStore>(
+                            context,
+                            listen: false,
+                          ).onSearchPage = true;
                         },
                       ),
                       SizedBox(width: isTablet ? 30 : 60),

--- a/lib/studies/reply/model/email_store.dart
+++ b/lib/studies/reply/model/email_store.dart
@@ -177,6 +177,7 @@ class EmailStore with ChangeNotifier {
 
   int _currentlySelectedEmailId = -1;
   String _currentlySelectedInbox = 'Inbox';
+  bool _onSearchPage = false;
 
   Map<String, Set<Email>> get emails =>
       Map<String, Set<Email>>.unmodifiable(_categories);
@@ -211,6 +212,7 @@ class EmailStore with ChangeNotifier {
   int get currentlySelectedEmailId => _currentlySelectedEmailId;
   String get currentlySelectedInbox => _currentlySelectedInbox;
   bool get onMailView => _currentlySelectedEmailId > -1;
+  bool get onSearchPage => _onSearchPage;
 
   bool isEmailStarred(Email email) {
     return _categories['Starred'].contains(email);
@@ -223,6 +225,11 @@ class EmailStore with ChangeNotifier {
 
   set currentlySelectedInbox(String inbox) {
     _currentlySelectedInbox = inbox;
+    notifyListeners();
+  }
+
+  set onSearchPage(bool value) {
+    _onSearchPage = value;
     notifyListeners();
   }
 }

--- a/lib/studies/reply/search_page.dart
+++ b/lib/studies/reply/search_page.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:gallery/studies/reply/model/email_store.dart';
+import 'package:provider/provider.dart';
 
 class SearchPage extends StatelessWidget {
   const SearchPage();
@@ -18,7 +20,12 @@ class SearchPage extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     BackButton(
-                      onPressed: () => Navigator.of(context).pop(),
+                      onPressed: () {
+                        Provider.of<EmailStore>(
+                          context,
+                          listen: false,
+                        ).onSearchPage = false;
+                      },
                     ),
                     const Expanded(
                       child: TextField(


### PR DESCRIPTION
This fixes a bug with the transition between Home<->SearchPage, where the home page would not fade through before the SearchPage scales in. 

* Implements a common `_SharedAxisTransitionSwitcher` that takes in  widget `defaultChild`, which is the widget that the SearchPage transitions on top of.
* `_SharedAxisTransitionSwitcher` uses a `Selector` to listen for `onSearchPage` boolean from `EmailStore` to determine whether to transition to the SearchPage. `Selector` only rebuilds its child widget when the specific value it is listening for has changed, and not any value in the `EmailStore`.
* Use PageTransitionSwitcher method of transitioning between screens over named routes for transitioning to SearchPage
* Add onSearchPage value to EmailStore to track if we are on the SearchPage
* Update any logic that referenced ReplyApp.searchRoute

Notes:
* Could be a bug with the animations package, similar behavior on motion demo for shared z axis transition.


Gif of bug(left: desired behavior, right: bug)|Fix
---|---
![reply-bug](https://user-images.githubusercontent.com/948037/91530474-fed52300-e8bf-11ea-8bfb-5a3c69f5f707.gif)|![reply-bug-search-fix](https://user-images.githubusercontent.com/948037/91531147-24aef780-e8c1-11ea-9d8c-cba0eeb32241.gif)